### PR TITLE
[fix] - range property constraint should also accept numerical values as strings

### DIFF
--- a/src/main/groovy/net/simonix/dsl/jmeter/model/constraint/RangePropertyConstraint.groovy
+++ b/src/main/groovy/net/simonix/dsl/jmeter/model/constraint/RangePropertyConstraint.groovy
@@ -57,6 +57,11 @@ class RangePropertyConstraint implements PropertyConstraint {
             return bigint.compareTo(BigInteger.valueOf(from)) >= 0 &&
                     bigint.compareTo(BigInteger.valueOf(to)) <= 0
         }
+        if (value instanceof String) {
+            Long convertedValue = value.asType(Long)
+
+            return convertedValue >= from && convertedValue <= to
+        }
         return false
     }
 }

--- a/src/test/groovy/net/simonix/dsl/jmeter/model/constraint/RangePropertyConstraintSpec.groovy
+++ b/src/test/groovy/net/simonix/dsl/jmeter/model/constraint/RangePropertyConstraintSpec.groovy
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2020 Szymon Micyk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.simonix.dsl.jmeter.model.constraint
+
+import spock.lang.Specification
+
+
+class RangePropertyConstraintSpec extends Specification  {
+
+    def "matches range with numbers"() {
+        given:
+        RangePropertyConstraint constraint = Constraints.range(-10, 10)
+
+        expect:
+        constraint.matches(value) == result
+
+        where:
+        value || result
+        0     || true
+        4     || true
+        -4    || true
+        10    || true
+        -10   || true
+        20    || false
+        -20   || false
+    }
+
+    def "matches range with BigInteger"() {
+        given:
+        RangePropertyConstraint constraint = Constraints.range(-10, 10)
+
+        expect:
+        constraint.matches(value) == result
+
+        where:
+        value || result
+        BigInteger.valueOf(0)     || true
+        BigInteger.valueOf(4)     || true
+        BigInteger.valueOf(-4)    || true
+        BigInteger.valueOf(10)    || true
+        BigInteger.valueOf(-10)   || true
+        BigInteger.valueOf(20)    || false
+        BigInteger.valueOf(-20)   || false
+    }
+
+    def "matches range with String"() {
+        given:
+        RangePropertyConstraint constraint = Constraints.range(-10, 10)
+
+        expect:
+        constraint.matches(value) == result
+
+        where:
+        value || result
+        '0'     || true
+        '4'     || true
+        '-4'    || true
+        '10'    || true
+        '-10'   || true
+        '20'    || false
+        '-20'   || false
+    }
+}


### PR DESCRIPTION
- numerical values can be strings if provided by command line or evaluated with GString expression