### PR TITLE
[bugfix] - command line variables not visible in the script

### DIFF
--- a/src/main/groovy/net/simonix/dsl/jmeter/TestScript.groovy
+++ b/src/main/groovy/net/simonix/dsl/jmeter/TestScript.groovy
@@ -76,14 +76,15 @@ abstract class TestScript extends TestScriptBase {
         }
 
         script.no_run = options.'no-run'
-
-        binding.setProperty('script', script)
+        script.variables = [:]
 
         if (options.Vs) {
             options.Vs.each { String name, String value ->
-                binding.setVariable(name, value)
+                script.variables[name] = value
             }
         }
+
+        binding.setProperty('script', script)
 
         updateJMeterClassPath()
 

--- a/src/main/groovy/net/simonix/dsl/jmeter/TestScriptBase.groovy
+++ b/src/main/groovy/net/simonix/dsl/jmeter/TestScriptBase.groovy
@@ -57,6 +57,14 @@ abstract class TestScriptBase extends Script {
 
         String saveToPath = saveTo != null ? saveTo : null
 
+        // add custom variables from command line
+        config.variables = [:]
+        if(script.variables) {
+            script.variables.each {
+                config.variables[it.key] = it.value
+            }
+        }
+
         HashTree configuration = TestScriptRunner.configure(config, c)
 
         if (saveToPath) {

--- a/src/main/groovy/net/simonix/dsl/jmeter/TestScriptRunner.groovy
+++ b/src/main/groovy/net/simonix/dsl/jmeter/TestScriptRunner.groovy
@@ -95,6 +95,12 @@ final class TestScriptRunner {
     static TestElementNode invokeBuilder(Map config, Closure closure) {
         DefaultFactoryBuilder builder = new DefaultFactoryBuilder()
 
+        if(config.variables) {
+            config.variables.each { entry ->
+                builder.setVariable(entry.key as String, entry.value)
+            }
+        }
+
         if (config.plugins) {
             config.plugins.each { factory ->
                 builder.registerPluginFactory(factory)

--- a/src/main/groovy/net/simonix/dsl/jmeter/builder/DefaultFactoryBuilder.groovy
+++ b/src/main/groovy/net/simonix/dsl/jmeter/builder/DefaultFactoryBuilder.groovy
@@ -178,7 +178,14 @@ class DefaultFactoryBuilder extends TestFactoryBuilder {
         if(node instanceof TestElementNode && JdbcFactoryBuilder.ACCEPTED_KEYWORDS.contains(node.name)) {
             Map<String, Object> parentContext = getProxyBuilder().getContext()
 
-            closure.delegate = new JdbcFactoryBuilder(parentContext, closure)
+            JdbcFactoryBuilder builder = new JdbcFactoryBuilder(parentContext, closure)
+
+            // copy any variables from command line to the child builder
+            this.variables.each { entry ->
+                builder.setVariable(entry.key as String, entry.value)
+            }
+
+            closure.delegate = builder
             closure.resolveStrategy = Closure.DELEGATE_ONLY
         } else {
             closure.delegate = this


### PR DESCRIPTION
- after change to resolveStrategy (DELEGATE_ONLY) command line variables are not visible inside script
- all variables are move to config parameter and added to builders binding instead of script