### PR TITLE
[feature] - add view tree result element

### DIFF
--- a/src/main/groovy/net/simonix/dsl/jmeter/builder/DefaultFactoryBuilder.groovy
+++ b/src/main/groovy/net/simonix/dsl/jmeter/builder/DefaultFactoryBuilder.groovy
@@ -32,10 +32,11 @@ import net.simonix.dsl.jmeter.factory.extractor.XPathExtractorFactory
 import net.simonix.dsl.jmeter.factory.group.GroupFactory
 import net.simonix.dsl.jmeter.factory.group.PostGroupFactory
 import net.simonix.dsl.jmeter.factory.group.PreGroupFactory
-import net.simonix.dsl.jmeter.factory.listener.AggregateFactory
+import net.simonix.dsl.jmeter.factory.listener.AggregateListenerFactory
 import net.simonix.dsl.jmeter.factory.listener.BackendListenerFactory
 import net.simonix.dsl.jmeter.factory.listener.JSR223ListenerFactory
-import net.simonix.dsl.jmeter.factory.listener.SummaryFactory
+import net.simonix.dsl.jmeter.factory.listener.SummaryListenerFactory
+import net.simonix.dsl.jmeter.factory.listener.ViewListenerFactory
 import net.simonix.dsl.jmeter.factory.plan.PlanFactory
 import net.simonix.dsl.jmeter.factory.plan.PlanVariableFactory
 import net.simonix.dsl.jmeter.factory.plan.PlanVariablesFactory
@@ -179,8 +180,9 @@ class DefaultFactoryBuilder extends TestFactoryBuilder {
         addFactory(new JdbcConfigFactory())
 
         // listeners
-        addFactory(new SummaryFactory())
-        addFactory(new AggregateFactory())
+        addFactory(new SummaryListenerFactory())
+        addFactory(new AggregateListenerFactory())
+        addFactory(new ViewListenerFactory())
         addFactory(new BackendListenerFactory())
         addFactory(new JSR223ListenerFactory())
     }

--- a/src/main/groovy/net/simonix/dsl/jmeter/factory/AbstractResultCollectorListenerFactory.groovy
+++ b/src/main/groovy/net/simonix/dsl/jmeter/factory/AbstractResultCollectorListenerFactory.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Szymon Micyk
+ * Copyright 2022 Szymon Micyk
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,77 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package net.simonix.dsl.jmeter.factory.listener
+package net.simonix.dsl.jmeter.factory
 
 import groovy.transform.CompileDynamic
-import net.simonix.dsl.jmeter.factory.TestElementNodeFactory
-import net.simonix.dsl.jmeter.model.definition.DslDefinition
+import net.simonix.dsl.jmeter.model.definition.KeywordDefinition
 import org.apache.jmeter.reporters.ResultCollector
 import org.apache.jmeter.reporters.Summariser
 import org.apache.jmeter.samplers.SampleSaveConfiguration
 import org.apache.jmeter.testelement.TestElement
-import org.apache.jmeter.visualizers.SummaryReport
 
 import static net.simonix.dsl.jmeter.utils.ConfigUtils.readValue
 
 /**
- * The factory class responsible for building <code>summary</code> element in the test.
- *
- * <pre>
- * // structure of the element
- * summary (
- *   file: string
- *   errorsOnly: boolean     [<strong>false</strong>]
- *   successesOnly: boolean  [<strong>false</strong>]
- *   assertions: boolean
- *   bytes: boolean
- *   code: boolean
- *   connectTime: boolean
- *   dataType: boolean
- *   encoding: boolean
- *   fieldNames: boolean
- *   fileName: boolean
- *   hostname: boolean
- *   idleTime: boolean
- *   label: boolean
- *   latency: boolean
- *   message: boolean
- *   requestHeaders: boolean
- *   responseData: boolean
- *   responseHeaders: boolean
- *   sampleCount: boolean
- *   samplerData: boolean
- *   sentBytes: boolean
- *   subresults: boolean
- *   success: boolean
- *   threadCounts: boolean
- *   threadName: boolean
- *   time: boolean
- *   timestamp: boolean
- *   url: boolean
- *   xml: boolean
- * ) {
- * }
- *
- * // example usage
- * start {
- *     plan {
- *         backend {
- *             summary file: 'summary.jtl', requestHeaders: true, xml: true
- *         }
- *     }
- * }
- * </pre>
- *
- * More details about the parameters are available at <a href="https://jmeter.apache.org/usermanual/component_reference.html#Summary_Report">Summary Report</a>
- *
- * @see TestElementNodeFactory TestElementNodeFactory
+ * Base class for all @{link ResultCollector} based test elements.
  */
 @CompileDynamic
-final class SummaryFactory extends TestElementNodeFactory {
+abstract class AbstractResultCollectorListenerFactory extends TestElementNodeFactory {
 
-    SummaryFactory() {
-        super(ResultCollector, SummaryReport, DslDefinition.SUMMARY)
+    AbstractResultCollectorListenerFactory(Class testElementGuiClass, KeywordDefinition definition) {
+        super(ResultCollector, testElementGuiClass, definition)
     }
 
     TestElement newTestElement(FactoryBuilderSupport builder, Object name, Object value, Map config) throws InstantiationException, IllegalAccessException {
@@ -93,7 +41,7 @@ final class SummaryFactory extends TestElementNodeFactory {
     }
 
     void updateTestElementProperties(TestElement testElement, Object name, Object value, Map config) {
-        testElement.filename = config.file
+        testElement.filename = readValue(value, config.file)
         testElement.errorLogging = config.errorsOnly
         testElement.successOnlyLogging = config.successesOnly
 

--- a/src/main/groovy/net/simonix/dsl/jmeter/factory/listener/AggregateListenerFactory.groovy
+++ b/src/main/groovy/net/simonix/dsl/jmeter/factory/listener/AggregateListenerFactory.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Szymon Micyk
+ * Copyright 2022 Szymon Micyk
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,14 +16,10 @@
 package net.simonix.dsl.jmeter.factory.listener
 
 import groovy.transform.CompileDynamic
+import net.simonix.dsl.jmeter.factory.AbstractResultCollectorListenerFactory
 import net.simonix.dsl.jmeter.factory.TestElementNodeFactory
 import net.simonix.dsl.jmeter.model.definition.DslDefinition
-import org.apache.jmeter.reporters.ResultCollector
-import org.apache.jmeter.reporters.Summariser
-import org.apache.jmeter.testelement.TestElement
 import org.apache.jmeter.visualizers.StatVisualizer
-
-import static net.simonix.dsl.jmeter.utils.ConfigUtils.readValue
 
 /**
  * The factory class responsible for building <code>aggregate</code> element in the test.
@@ -31,7 +27,37 @@ import static net.simonix.dsl.jmeter.utils.ConfigUtils.readValue
  * <pre>
  * // structure of the element
  * aggregate (
+ *   enabled: boolean        [<strong>false</strong>]
  *   file: string
+ *   errorsOnly: boolean     [<strong>false</strong>]
+ *   successesOnly: boolean  [<strong>false</strong>]
+ *   assertions: boolean
+ *   bytes: boolean
+ *   code: boolean
+ *   connectTime: boolean
+ *   dataType: boolean
+ *   encoding: boolean
+ *   fieldNames: boolean
+ *   fileName: boolean
+ *   hostname: boolean
+ *   idleTime: boolean
+ *   label: boolean
+ *   latency: boolean
+ *   message: boolean
+ *   requestHeaders: boolean
+ *   responseData: boolean
+ *   responseHeaders: boolean
+ *   sampleCount: boolean
+ *   samplerData: boolean
+ *   sentBytes: boolean
+ *   subresults: boolean
+ *   success: boolean
+ *   threadCounts: boolean
+ *   threadName: boolean
+ *   time: boolean
+ *   timestamp: boolean
+ *   url: boolean
+ *   xml: boolean
  * ) {
  * }
  *
@@ -48,19 +74,9 @@ import static net.simonix.dsl.jmeter.utils.ConfigUtils.readValue
  * @see TestElementNodeFactory TestElementNodeFactory
  */
 @CompileDynamic
-final class AggregateFactory extends TestElementNodeFactory {
+final class AggregateListenerFactory extends AbstractResultCollectorListenerFactory {
 
-    AggregateFactory() {
-        super(ResultCollector, StatVisualizer, DslDefinition.AGGREGATE)
-    }
-
-    TestElement newTestElement(FactoryBuilderSupport builder, Object name, Object value, Map config) throws InstantiationException, IllegalAccessException {
-        Summariser summariser = new Summariser()
-
-        return new ResultCollector(summariser)
-    }
-
-    void updateTestElementProperties(TestElement testElement, Object name, Object value, Map config) {
-        testElement.filename = readValue(value, config.file)
+    AggregateListenerFactory() {
+        super(StatVisualizer, DslDefinition.AGGREGATE)
     }
 }

--- a/src/main/groovy/net/simonix/dsl/jmeter/factory/listener/SummaryListenerFactory.groovy
+++ b/src/main/groovy/net/simonix/dsl/jmeter/factory/listener/SummaryListenerFactory.groovy
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2022 Szymon Micyk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.simonix.dsl.jmeter.factory.listener
+
+import groovy.transform.CompileDynamic
+import net.simonix.dsl.jmeter.factory.AbstractResultCollectorListenerFactory
+import net.simonix.dsl.jmeter.factory.TestElementNodeFactory
+import net.simonix.dsl.jmeter.model.definition.DslDefinition
+import org.apache.jmeter.visualizers.SummaryReport
+
+/**
+ * The factory class responsible for building <code>summary</code> element in the test.
+ *
+ * <pre>
+ * // structure of the element
+ * summary (
+ *   enabled: boolean        [<strong>false</strong>]
+ *   file: string
+ *   errorsOnly: boolean     [<strong>false</strong>]
+ *   successesOnly: boolean  [<strong>false</strong>]
+ *   assertions: boolean
+ *   bytes: boolean
+ *   code: boolean
+ *   connectTime: boolean
+ *   dataType: boolean
+ *   encoding: boolean
+ *   fieldNames: boolean
+ *   fileName: boolean
+ *   hostname: boolean
+ *   idleTime: boolean
+ *   label: boolean
+ *   latency: boolean
+ *   message: boolean
+ *   requestHeaders: boolean
+ *   responseData: boolean
+ *   responseHeaders: boolean
+ *   sampleCount: boolean
+ *   samplerData: boolean
+ *   sentBytes: boolean
+ *   subresults: boolean
+ *   success: boolean
+ *   threadCounts: boolean
+ *   threadName: boolean
+ *   time: boolean
+ *   timestamp: boolean
+ *   url: boolean
+ *   xml: boolean
+ * ) {
+ * }
+ *
+ * // example usage
+ * start {
+ *     plan {
+ *          summary file: 'summary.jtl', requestHeaders: true, xml: true
+ *     }
+ * }
+ * </pre>
+ *
+ * More details about the parameters are available at <a href="https://jmeter.apache.org/usermanual/component_reference.html#Summary_Report">Summary Report</a>
+ *
+ * @see TestElementNodeFactory TestElementNodeFactory
+ */
+@CompileDynamic
+final class SummaryListenerFactory extends AbstractResultCollectorListenerFactory {
+
+    SummaryListenerFactory() {
+        super(SummaryReport, DslDefinition.SUMMARY)
+    }
+}

--- a/src/main/groovy/net/simonix/dsl/jmeter/factory/listener/ViewListenerFactory.groovy
+++ b/src/main/groovy/net/simonix/dsl/jmeter/factory/listener/ViewListenerFactory.groovy
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2022 Szymon Micyk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.simonix.dsl.jmeter.factory.listener
+
+import groovy.transform.CompileDynamic
+import net.simonix.dsl.jmeter.factory.AbstractResultCollectorListenerFactory
+import net.simonix.dsl.jmeter.factory.TestElementNodeFactory
+import net.simonix.dsl.jmeter.model.definition.DslDefinition
+import org.apache.jmeter.visualizers.ViewResultsFullVisualizer
+
+/**
+ * The factory class responsible for building <code>view</code> element in the test.
+ *
+ * <pre>
+ * // structure of the element
+ * view (
+ *   enabled: boolean        [<strong>false</strong>]
+ *   file: string
+ *   errorsOnly: boolean     [<strong>false</strong>]
+ *   successesOnly: boolean  [<strong>false</strong>]
+ *   assertions: boolean
+ *   bytes: boolean
+ *   code: boolean
+ *   connectTime: boolean
+ *   dataType: boolean
+ *   encoding: boolean
+ *   fieldNames: boolean
+ *   fileName: boolean
+ *   hostname: boolean
+ *   idleTime: boolean
+ *   label: boolean
+ *   latency: boolean
+ *   message: boolean
+ *   requestHeaders: boolean
+ *   responseData: boolean
+ *   responseHeaders: boolean
+ *   sampleCount: boolean
+ *   samplerData: boolean
+ *   sentBytes: boolean
+ *   subresults: boolean
+ *   success: boolean
+ *   threadCounts: boolean
+ *   threadName: boolean
+ *   time: boolean
+ *   timestamp: boolean
+ *   url: boolean
+ *   xml: boolean
+ * ) {
+ * }
+ *
+ * // example usage
+ * start {
+ *     plan {
+ *         view 'filename.jtl'
+ *     }
+ * }
+ * </pre>
+ *
+ * More details about the parameters are available at <a href="https://jmeter.apache.org/usermanual/component_reference.html#View_Results_Tree">View Results Tree</a>
+ *
+ * @see TestElementNodeFactory TestElementNodeFactory
+ */
+@CompileDynamic
+final class ViewListenerFactory extends AbstractResultCollectorListenerFactory {
+
+    ViewListenerFactory() {
+        super(ViewResultsFullVisualizer, DslDefinition.VIEW)
+    }
+}

--- a/src/main/groovy/net/simonix/dsl/jmeter/model/constraint/InListPropertyConstraint.groovy
+++ b/src/main/groovy/net/simonix/dsl/jmeter/model/constraint/InListPropertyConstraint.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Szymon Micyk
+ * Copyright 2022 Szymon Micyk
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,12 +15,13 @@
  */
 package net.simonix.dsl.jmeter.model.constraint
 
+import groovy.transform.CompileDynamic
+import groovy.transform.Immutable
+
+@Immutable
+@CompileDynamic
 class InListPropertyConstraint implements PropertyConstraint {
     List<String> values
-
-    InListPropertyConstraint(List<String> values) {
-        this.values = values.asImmutable()
-    }
 
     @Override
     boolean matches(Object value) {

--- a/src/main/groovy/net/simonix/dsl/jmeter/model/constraint/RangePropertyConstraint.groovy
+++ b/src/main/groovy/net/simonix/dsl/jmeter/model/constraint/RangePropertyConstraint.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Szymon Micyk
+ * Copyright 2022 Szymon Micyk
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,15 +15,15 @@
  */
 package net.simonix.dsl.jmeter.model.constraint
 
+import groovy.transform.CompileDynamic
+import groovy.transform.Immutable
+
+@Immutable
+@CompileDynamic
 class RangePropertyConstraint implements PropertyConstraint {
 
     Long from
     Long to
-
-    RangePropertyConstraint(Long from, Long to) {
-        this.from = from
-        this.to = to
-    }
 
     @Override
     boolean matches(Object value) {

--- a/src/main/groovy/net/simonix/dsl/jmeter/model/definition/DslDefinition.groovy
+++ b/src/main/groovy/net/simonix/dsl/jmeter/model/definition/DslDefinition.groovy
@@ -30,6 +30,39 @@ final class DslDefinition {
         property(name: 'enabled', type: Boolean, required: false, defaultValue: true)
     }
 
+    static final Set<PropertyDefinition> LISTENER_PROPERTIES = properties {
+        property(name: 'file', type: String, required: true, defaultValue: '')
+        property(name: 'errorsOnly', type: Boolean, required: false, defaultValue: false)
+        property(name: 'successesOnly', type: Boolean, required: false, defaultValue: false)
+        property(name: 'assertions', type: Boolean, required: false)
+        property(name: 'bytes', type: Boolean, required: false)
+        property(name: 'code', type: Boolean, required: false)
+        property(name: 'connectTime', type: Boolean, required: false)
+        property(name: 'dataType', type: Boolean, required: false)
+        property(name: 'encoding', type: Boolean, required: false)
+        property(name: 'fieldNames', type: Boolean, required: false)
+        property(name: 'fileName', type: Boolean, required: false)
+        property(name: 'hostname', type: Boolean, required: false)
+        property(name: 'idleTime', type: Boolean, required: false)
+        property(name: 'label', type: Boolean, required: false)
+        property(name: 'latency', type: Boolean, required: false)
+        property(name: 'message', type: Boolean, required: false)
+        property(name: 'requestHeaders', type: Boolean, required: false)
+        property(name: 'responseData', type: Boolean, required: false)
+        property(name: 'responseHeaders', type: Boolean, required: false)
+        property(name: 'sampleCount', type: Boolean, required: false)
+        property(name: 'samplerData', type: Boolean, required: false)
+        property(name: 'sentBytes', type: Boolean, required: false)
+        property(name: 'subresults', type: Boolean, required: false)
+        property(name: 'success', type: Boolean, required: false)
+        property(name: 'threadCounts', type: Boolean, required: false)
+        property(name: 'threadName', type: Boolean, required: false)
+        property(name: 'time', type: Boolean, required: false)
+        property(name: 'timestamp', type: Boolean, required: false)
+        property(name: 'url', type: Boolean, required: false)
+        property(name: 'xml', type: Boolean, required: false)
+    }
+
     // plan
     static final KeywordDefinition PLAN = keyword('plan', KeywordCategory.PLAN) {
         include(COMMON_PROPERTIES)
@@ -779,7 +812,30 @@ final class DslDefinition {
     // listeners
     static final KeywordDefinition AGGREGATE = keyword('aggregate', KeywordCategory.LISTENER) {
         include(COMMON_PROPERTIES)
-        property(name: 'file', type: String, required: true, defaultValue: '')
+        include(LISTENER_PROPERTIES)
+
+        override(name: 'enabled', type: Boolean, required: false, defaultValue: false)
+
+        leaf()
+        valueIsProperty()
+    }
+
+    static final KeywordDefinition VIEW = keyword('view', KeywordCategory.LISTENER) {
+        include(COMMON_PROPERTIES)
+        include(LISTENER_PROPERTIES)
+
+        override(name: 'enabled', type: Boolean, required: false, defaultValue: false)
+
+        leaf()
+        valueIsProperty()
+    }
+
+    static final KeywordDefinition SUMMARY = keyword('summary', KeywordCategory.LISTENER) {
+        include(COMMON_PROPERTIES)
+        include(LISTENER_PROPERTIES)
+
+        override(name: 'enabled', type: Boolean, required: false, defaultValue: false)
+
         leaf()
         valueIsProperty()
     }
@@ -798,43 +854,6 @@ final class DslDefinition {
 
     static final KeywordDefinition BACKEND_ARGUMENTS = keyword('arguments', KeywordCategory.LISTENER, 'backend_') {
         property(name: 'values', type: Map, required: false, defaultValue: [:])
-    }
-
-
-    static final KeywordDefinition SUMMARY = keyword('summary', KeywordCategory.LISTENER) {
-        include(COMMON_PROPERTIES)
-        property(name: 'file', type: String, required: true, defaultValue: '')
-        property(name: 'errorsOnly', type: Boolean, required: false, defaultValue: false)
-        property(name: 'successesOnly', type: Boolean, required: false, defaultValue: false)
-        property(name: 'assertions', type: Boolean, required: false)
-        property(name: 'bytes', type: Boolean, required: false)
-        property(name: 'code', type: Boolean, required: false)
-        property(name: 'connectTime', type: Boolean, required: false)
-        property(name: 'dataType', type: Boolean, required: false)
-        property(name: 'encoding', type: Boolean, required: false)
-        property(name: 'fieldNames', type: Boolean, required: false)
-        property(name: 'fileName', type: Boolean, required: false)
-        property(name: 'hostname', type: Boolean, required: false)
-        property(name: 'idleTime', type: Boolean, required: false)
-        property(name: 'label', type: Boolean, required: false)
-        property(name: 'latency', type: Boolean, required: false)
-        property(name: 'message', type: Boolean, required: false)
-        property(name: 'requestHeaders', type: Boolean, required: false)
-        property(name: 'responseData', type: Boolean, required: false)
-        property(name: 'responseHeaders', type: Boolean, required: false)
-        property(name: 'sampleCount', type: Boolean, required: false)
-        property(name: 'samplerData', type: Boolean, required: false)
-        property(name: 'sentBytes', type: Boolean, required: false)
-        property(name: 'subresults', type: Boolean, required: false)
-        property(name: 'success', type: Boolean, required: false)
-        property(name: 'threadCounts', type: Boolean, required: false)
-        property(name: 'threadName', type: Boolean, required: false)
-        property(name: 'time', type: Boolean, required: false)
-        property(name: 'timestamp', type: Boolean, required: false)
-        property(name: 'url', type: Boolean, required: false)
-        property(name: 'xml', type: Boolean, required: false)
-        leaf()
-        valueIsProperty()
     }
 
     static final KeywordDefinition JSR223_LISTENER = keyword('jsrlistener', KeywordCategory.LISTENER) {

--- a/src/main/groovy/net/simonix/dsl/jmeter/model/definition/KeywordDefinition.groovy
+++ b/src/main/groovy/net/simonix/dsl/jmeter/model/definition/KeywordDefinition.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Szymon Micyk
+ * Copyright 2022 Szymon Micyk
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,31 +16,18 @@
 package net.simonix.dsl.jmeter.model.definition
 
 import groovy.transform.CompileDynamic
-import groovy.transform.EqualsAndHashCode
-import groovy.transform.ToString
+import groovy.transform.Immutable
 
-@ToString
-@EqualsAndHashCode
+@Immutable
 @CompileDynamic
 class KeywordDefinition {
 
-    final String name
-    final String prefix
-    final String title
-    final String description
-    final String category
-    final boolean leaf
-    final boolean valueIsProperty
-    final Set<PropertyDefinition> properties
-
-    KeywordDefinition(String name, String prefix, KeywordCategory category, String title, String description, boolean leaf, boolean valueIsProperty, Set<PropertyDefinition> properties) {
-        this.name = name
-        this.prefix = prefix
-        this.category = category
-        this.title = title
-        this.description = description
-        this.leaf = leaf
-        this.valueIsProperty = valueIsProperty
-        this.properties = properties.asImmutable()
-    }
+    String name
+    String prefix
+    String title
+    String description
+    String category
+    boolean leaf
+    boolean valueIsProperty
+    Set<PropertyDefinition> properties
 }

--- a/src/main/groovy/net/simonix/dsl/jmeter/model/definition/PropertyDefinition.groovy
+++ b/src/main/groovy/net/simonix/dsl/jmeter/model/definition/PropertyDefinition.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Szymon Micyk
+ * Copyright 2022 Szymon Micyk
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,10 @@
 package net.simonix.dsl.jmeter.model.definition
 
 import groovy.transform.CompileDynamic
-import groovy.transform.EqualsAndHashCode
-import groovy.transform.ToString
+import groovy.transform.Immutable
 import net.simonix.dsl.jmeter.model.constraint.PropertyConstraint
 
-@ToString
-@EqualsAndHashCode
+@Immutable(knownImmutables = ['defaultValue', 'constraints'])
 @CompileDynamic
 class PropertyDefinition {
 

--- a/src/main/resources/net/simonix/dsl/jmeter/model/definition/messages.properties
+++ b/src/main/resources/net/simonix/dsl/jmeter/model/definition/messages.properties
@@ -1506,20 +1506,6 @@ jsrtimer.property.language.description=
 
 ## listeners
 
-# aggregate
-aggregate.title=Aggregate Report
-aggregate.description=Defines 'Aggregate Report' element
-
-aggregate.property.name.title=Name
-aggregate.property.name.description=Name
-aggregate.property.comments.title=Comments
-aggregate.property.comments.description=Comments
-aggregate.property.enabled.title=Enabled
-aggregate.property.enabled.description=Enabled
-
-aggregate.property.file.title=
-aggregate.property.file.description=
-
 # backend
 backend.title=Backend Listener
 backend.description=Defines 'Backend Listener' element
@@ -1551,6 +1537,79 @@ backend_arguments.description=Defines user variables element inside a backend li
 
 backend_arguments.property.values.title=
 backend_arguments.property.values.description=
+
+# aggregate
+aggregate.title=Aggregate Report
+aggregate.description=Defines 'Aggregate Report' element
+
+aggregate.property.name.title=Name
+aggregate.property.name.description=Name
+aggregate.property.comments.title=Comments
+aggregate.property.comments.description=Comments
+aggregate.property.enabled.title=Enabled
+aggregate.property.enabled.description=Enabled
+
+aggregate.property.file.title=
+aggregate.property.file.description=
+aggregate.property.errorsOnly.title=
+aggregate.property.errorsOnly.description=
+aggregate.property.successesOnly.title=
+aggregate.property.successesOnly.description=
+aggregate.property.assertions.title=
+aggregate.property.assertions.description=
+aggregate.property.bytes.title=
+aggregate.property.bytes.description=
+aggregate.property.code.title=
+aggregate.property.code.description=
+aggregate.property.connectTime.title=
+aggregate.property.connectTime.description=
+aggregate.property.dataType.title=
+aggregate.property.dataType.description=
+aggregate.property.encoding.title=
+aggregate.property.encoding.description=
+aggregate.property.fieldNames.title=
+aggregate.property.fieldNames.description=
+aggregate.property.fileName.title=
+aggregate.property.fileName.description=
+aggregate.property.hostname.title=
+aggregate.property.hostname.description=
+aggregate.property.idleTime.title=
+aggregate.property.idleTime.description=
+aggregate.property.label.title=
+aggregate.property.label.description=
+aggregate.property.latency.title=
+aggregate.property.latency.description=
+aggregate.property.message.title=
+aggregate.property.message.description=
+aggregate.property.requestHeaders.title=
+aggregate.property.requestHeaders.description=
+aggregate.property.responseData.title=
+aggregate.property.responseData.description=
+
+aggregate.property.responseHeaders.title=
+aggregate.property.responseHeaders.description=
+aggregate.property.sampleCount.title=
+aggregate.property.sampleCount.description=
+aggregate.property.samplerData.title=
+aggregate.property.samplerData.description=
+aggregate.property.sentBytes.title=
+aggregate.property.sentBytes.description=
+aggregate.property.subresults.title=
+aggregate.property.subresults.description=
+aggregate.property.success.title=
+aggregate.property.success.description=
+aggregate.property.threadCounts.title=
+aggregate.property.threadCounts.description=
+aggregate.property.threadName.title=
+aggregate.property.threadName.description=
+aggregate.property.time.title=
+aggregate.property.time.description=
+aggregate.property.timestamp.title=
+aggregate.property.timestamp.description=
+aggregate.property.url.title=
+aggregate.property.url.description=
+aggregate.property.xml.title=
+aggregate.property.xml.description=
 
 # summary
 summary.title=Summary Report
@@ -1624,6 +1683,79 @@ summary.property.url.title=
 summary.property.url.description=
 summary.property.xml.title=
 summary.property.xml.description=
+
+# view
+view.title=View Report
+view.description=Defines 'View Result Tree' element
+
+view.property.name.title=Name
+view.property.name.description=Name
+view.property.comments.title=Comments
+view.property.comments.description=Comments
+view.property.enabled.title=Enabled
+view.property.enabled.description=Enabled
+
+view.property.file.title=
+view.property.file.description=
+view.property.errorsOnly.title=
+view.property.errorsOnly.description=
+view.property.successesOnly.title=
+view.property.successesOnly.description=
+view.property.assertions.title=
+view.property.assertions.description=
+view.property.bytes.title=
+view.property.bytes.description=
+view.property.code.title=
+view.property.code.description=
+view.property.connectTime.title=
+view.property.connectTime.description=
+view.property.dataType.title=
+view.property.dataType.description=
+view.property.encoding.title=
+view.property.encoding.description=
+view.property.fieldNames.title=
+view.property.fieldNames.description=
+view.property.fileName.title=
+view.property.fileName.description=
+view.property.hostname.title=
+view.property.hostname.description=
+view.property.idleTime.title=
+view.property.idleTime.description=
+view.property.label.title=
+view.property.label.description=
+view.property.latency.title=
+view.property.latency.description=
+view.property.message.title=
+view.property.message.description=
+view.property.requestHeaders.title=
+view.property.requestHeaders.description=
+view.property.responseData.title=
+view.property.responseData.description=
+
+view.property.responseHeaders.title=
+view.property.responseHeaders.description=
+view.property.sampleCount.title=
+view.property.sampleCount.description=
+view.property.samplerData.title=
+view.property.samplerData.description=
+view.property.sentBytes.title=
+view.property.sentBytes.description=
+view.property.subresults.title=
+view.property.subresults.description=
+view.property.success.title=
+view.property.success.description=
+view.property.threadCounts.title=
+view.property.threadCounts.description=
+view.property.threadName.title=
+view.property.threadName.description=
+view.property.time.title=
+view.property.time.description=
+view.property.timestamp.title=
+view.property.timestamp.description=
+view.property.url.title=
+view.property.url.description=
+view.property.xml.title=
+view.property.xml.description=
 
 # jsrlistener
 jsrlistener.title=JSR223 Listener

--- a/src/test/groovy/net/simonix/dsl/jmeter/factory/listener/ListenerFactorySpec.groovy
+++ b/src/test/groovy/net/simonix/dsl/jmeter/factory/listener/ListenerFactorySpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Szymon Micyk
+ * Copyright 2022 Szymon Micyk
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ class ListenerFactorySpec extends TempFileSpec {
             plan {
                 aggregate(name: 'Aggregate', file: 'aggregate.jtl')
                 summary(name: 'My Summary', file: 'example.jtl')
+                view(name: 'My View', file: 'view.jtl')
 
                 backend(name: 'Backend Listener', enabled: false) {
                     arguments {

--- a/src/test/resources/net/simonix/dsl/jmeter/factory/listener/listeners_0.jmx
+++ b/src/test/resources/net/simonix/dsl/jmeter/factory/listener/listeners_0.jmx
@@ -29,7 +29,7 @@
       </elementProp>
     </TestPlan>
     <hashTree>
-      <ResultCollector guiclass="StatVisualizer" testclass="ResultCollector" testname="Aggregate" enabled="true">
+      <ResultCollector guiclass="StatVisualizer" testclass="ResultCollector" testname="Aggregate" enabled="false">
         <boolProp name="ResultCollector.error_logging">false</boolProp>
         <objProp>
           <name>saveConfig</name>
@@ -66,7 +66,7 @@
         <stringProp name="filename">aggregate.jtl</stringProp>
       </ResultCollector>
       <hashTree/>
-      <ResultCollector guiclass="SummaryReport" testclass="ResultCollector" testname="My Summary" enabled="true">
+      <ResultCollector guiclass="SummaryReport" testclass="ResultCollector" testname="My Summary" enabled="false">
         <boolProp name="ResultCollector.error_logging">false</boolProp>
         <objProp>
           <name>saveConfig</name>
@@ -101,6 +101,43 @@
           </value>
         </objProp>
         <stringProp name="filename">example.jtl</stringProp>
+      </ResultCollector>
+      <hashTree/>
+      <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="My View" enabled="false">
+        <boolProp name="ResultCollector.error_logging">false</boolProp>
+        <objProp>
+          <name>saveConfig</name>
+          <value class="SampleSaveConfiguration">
+            <time>true</time>
+            <latency>true</latency>
+            <timestamp>true</timestamp>
+            <success>true</success>
+            <label>true</label>
+            <code>true</code>
+            <message>true</message>
+            <threadName>true</threadName>
+            <dataType>true</dataType>
+            <encoding>false</encoding>
+            <assertions>true</assertions>
+            <subresults>true</subresults>
+            <responseData>false</responseData>
+            <samplerData>false</samplerData>
+            <xml>false</xml>
+            <fieldNames>true</fieldNames>
+            <responseHeaders>false</responseHeaders>
+            <requestHeaders>false</requestHeaders>
+            <responseDataOnError>false</responseDataOnError>
+            <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+            <assertionsResultsToSave>0</assertionsResultsToSave>
+            <bytes>true</bytes>
+            <sentBytes>true</sentBytes>
+            <url>true</url>
+            <threadCounts>true</threadCounts>
+            <idleTime>true</idleTime>
+            <connectTime>true</connectTime>
+          </value>
+        </objProp>
+        <stringProp name="filename">view.jtl</stringProp>
       </ResultCollector>
       <hashTree/>
       <BackendListener guiclass="BackendListenerGui" testclass="BackendListener" testname="Backend Listener" enabled="false">


### PR DESCRIPTION
Implementation for #59 

- new factory for result view tree listener
- keep all listeners to use same based class for common functionality
- use immutable on KeywordDefinition and PropertyDefinition to avoid accidental override of values