### PR TITLE
[feature] - add J and G parameters and enable expression in different…

### DIFF
--- a/examples/application/docker-compose.yml
+++ b/examples/application/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     command: ["groovy", "script.groovy"]
 
   grafana:
-    image: grafana/grafana:latest
+    image: grafana/grafana:8.5.5
     container_name: grafana-app
     ports:
       - 3000:3000
@@ -42,7 +42,7 @@ services:
       GF_SECURITY_ADMIN_PASSWORD: admin
 
   influxdb:
-    image: influxdb:1.5.4
+    image: influxdb:1.8.10
     container_name: influxdb-app
     ports:
       - 8083:8083
@@ -56,7 +56,7 @@ services:
       INFLUXDB_ADMIN_PASSWORD: "jmeter"
 
   telegraf:
-    image: telegraf:1.8.3
+    image: telegraf:1.22.4
     container_name: telegraf-app
     links:
       - influxdb:influxdb-app

--- a/examples/commandline/run.bat
+++ b/examples/commandline/run.bat
@@ -1,3 +1,3 @@
 @echo off
 
-groovy script.groovy -Vjmt_host=localhost -Vjmt_users=1 -Vjmt_ramp=10 -Vjmt_user_nm=john -Vjmt_user_pw=john
+groovy script.groovy -Vvar_host=localhost -Vvar_users=1 -Vvar_ramp=10 -Vvar_user=john -Vvar_pass=john

--- a/examples/commandline/run.sh
+++ b/examples/commandline/run.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-groovy script.groovy -Vjmt_host=localhost -Vjmt_users=1 -Vjmt_ramp=10 -Vjmt_user_nm=john -Vjmt_user_pw=john
+groovy script.groovy -Vvar_host=localhost -Vvar_users=1 -Vvar_ramp=10 -Vvar_user=john -Vvar_pass=john

--- a/examples/commandline/script.groovy
+++ b/examples/commandline/script.groovy
@@ -6,20 +6,20 @@
 start {
     plan {
         arguments {
-            argument(name: 'var_host', value: "${jmt_host}")
-            argument(name: 'var_user_nm', value: "${jmt_user_nm}")
-            argument(name: 'var_user_pw', value: "${jmt_user_pw}")
+            argument(name: 'var_host', value: "${var_host}")
+            argument(name: 'var_user', value: "${var_user}")
+            argument(name: 'var_pass', value: "${var_pass}")
         }
 
         defaults(protocol: 'http', domain: '${var_host}', port: 1080)
 
-        group(users: jmt_users, rampUp: jmt_ramp) {
+        group(users: var_users, rampUp: var_ramp) {
             cookies(name: 'cookies manager')
 
             http('POST /login') {
                 params {
-                    param(name: 'username', value: '${var_user_nm}')
-                    param(name: 'password', value: '${var_user_pw}')
+                    param(name: 'username', value: '${var_user}')
+                    param(name: 'password', value: '${var_pass}')
                 }
 
                 extract_regex expression: '"trackId", content="([0-9]+)"', variable: 'var_trackId'

--- a/examples/database/docker-compose.yml
+++ b/examples/database/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     command: ["groovy", "script.groovy"]
 
   grafana:
-    image: grafana/grafana:latest
+    image: grafana/grafana:8.5.5
     container_name: grafana-db
     ports:
       - 3000:3000
@@ -40,7 +40,7 @@ services:
       GF_SECURITY_ADMIN_PASSWORD: admin
 
   influxdb:
-    image: influxdb:1.5.4
+    image: influxdb:1.8.10
     container_name: influxdb-db
     ports:
       - 8083:8083
@@ -54,7 +54,7 @@ services:
       INFLUXDB_ADMIN_PASSWORD: "jmeter"
 
   telegraf:
-    image: telegraf:1.8.3
+    image: telegraf:1.22.4
     container_name: telegraf-db
     links:
       - influxdb:influxdb-db

--- a/examples/distributed/docker-compose.yml
+++ b/examples/distributed/docker-compose.yml
@@ -40,7 +40,7 @@ services:
     volumes:
       - .:/home/groovy
       - grapes-cache:/home/groovy/.groovy/grapes
-    command: ["groovy", "script.groovy", "-c", "-r", "worker1-server:1099", "-r", "worker2-server:1099", "-r", "worker3-server:1099"]
+    command: ["groovy", "script.groovy", "-c", "-r", "worker1-server:1099", "-r", "worker2-server:1099", "-r", "worker3-server:1099", "-Gvar_users=1000", "-Gvar_rampUp=300"]
     depends_on:
       - worker1
       - worker2

--- a/examples/distributed/script.groovy
+++ b/examples/distributed/script.groovy
@@ -9,13 +9,16 @@ start {
         // add user define variables
         arguments {
             argument(name: 'var_host', value: 'mockserver-books')
+
+            argument(name: 'var_users', value: '${__P(var_users,1)}')
+            argument(name: 'var_rampUp', value: '${__P(var_rampUp,1)}')
         }
 
         // define HTTP default values
         defaults(protocol: 'http', domain: '${var_host}', port: 1080)
 
         // define group of 1000 users with ramp up period 300 seconds
-        group(users: 1000, rampUp: 300) {
+        group(users: '${var_users}', rampUp: '${var_rampUp}') {
             // add cookie manager for HTTP requests
             cookies(name: 'cookies manager')
 

--- a/examples/monitoring/docker-compose.yml
+++ b/examples/monitoring/docker-compose.yml
@@ -10,7 +10,7 @@ networks:
 
 services:
   grafana:
-    image: grafana/grafana:latest
+    image: grafana/grafana:8.5.5
     container_name: grafana-books
     ports:
       - 3000:3000
@@ -25,7 +25,7 @@ services:
       GF_SECURITY_ADMIN_PASSWORD: admin
 
   influxdb:
-    image: influxdb:1.8.0
+    image: influxdb:1.8.10
     container_name: influxdb-books
     ports:
       - 8083:8083
@@ -39,7 +39,7 @@ services:
       INFLUXDB_ADMIN_PASSWORD: "jmeter"
 
   telegraf:
-    image: telegraf:1.14.4
+    image: telegraf:1.22.4
     container_name: telegraf-books
     links:
       - influxdb:influxdb-books

--- a/examples/parameters/run.bat
+++ b/examples/parameters/run.bat
@@ -1,0 +1,3 @@
+@echo off
+
+groovy script.groovy -Vvar_host=localhost -Vvar_port=1080 -Vvar_user=john -Vvar_pass=john -Jvar_users=6 -Jvar_ramp=10 -Jvar_delay=3000 -Jvar_range=8000

--- a/examples/parameters/run.sh
+++ b/examples/parameters/run.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+groovy script.groovy -Vvar_host=localhost -Vvar_port=1080 -Vvar_user=john -Vvar_pass=john -Jvar_users=6 -Jvar_ramp=10 -Jvar_delay=3000 -Jvar_range=8000

--- a/examples/parameters/script.groovy
+++ b/examples/parameters/script.groovy
@@ -1,0 +1,49 @@
+@GrabConfig(systemClassLoader=true)
+@Grab('net.simonix.scripts:groovy-jmeter')
+
+@groovy.transform.BaseScript net.simonix.dsl.jmeter.TestScript script
+
+start {
+    plan {
+        arguments {
+            argument(name: 'var_host', value: "${var_host}")
+            argument(name: 'var_port', value: "${var_port}")
+            argument(name: 'var_user', value: "${var_user}")
+            argument(name: 'var_pass', value: "${var_pass}")
+
+            argument(name: 'var_users', value: '${__P(var_users, 2)}')
+            argument(name: 'var_ramp', value: '${__P(var_ramp, 5)}')
+            argument(name: 'var_range', value: '${__P(var_range, 6000)}')
+            argument(name: 'var_delay', value: '${__P(var_delay, 2000)}')
+        }
+
+        defaults(protocol: 'http', domain: '${var_host}', port: '${var_port}')
+
+        group(users: '${var_users}', rampUp: '${var_ramp}') {
+            uniform_timer(range: '${var_range}', delay: '${var_delay}')
+
+            http('POST /login') {
+                params {
+                    param(name: 'username', value: '${var_user}')
+                    param(name: 'password', value: '${var_pass}')
+                }
+            }
+        }
+
+        summary(file: 'script.jtl', enabled: true)
+
+        backend(name: 'InfluxDb Backend', enabled: true) {
+            arguments {
+                argument(name: 'influxdbMetricsSender', value: 'org.apache.jmeter.visualizers.backend.influxdb.HttpMetricsSender')
+                argument(name: 'influxdbUrl', value: 'http://localhost:8086/write?db=jmeter')
+                argument(name: 'application', value: 'books')
+                argument(name: 'measurement', value: 'performance')
+                argument(name: 'summaryOnly', value: 'false')
+                argument(name: 'samplersRegex', value: '.*')
+                argument(name: 'percentiles', value: '90;95;99')
+                argument(name: 'testTitle', value: 'books - users: 1000, rampup: 300')
+                argument(name: "eventTags", value: '')
+            }
+        }
+    }
+}

--- a/src/main/groovy/net/simonix/dsl/jmeter/TestScript.groovy
+++ b/src/main/groovy/net/simonix/dsl/jmeter/TestScript.groovy
@@ -51,6 +51,8 @@ abstract class TestScript extends TestScriptBase {
         cliBuilder.with {
             h(longOpt: 'help', args: 0, 'Show help message')
             V(longOpt: 'vars', type: Map, valueSeparator: '=', argName: 'variable=value', 'Define values for placeholders in the script')
+            J(longOpt: 'jvars', type: Map, valueSeparator: '=', argName: 'variable=value', 'Define local JMeter property')
+            G(longOpt: 'gvars', type: Map, valueSeparator: '=', argName: 'variable=value', 'Define global JMeter property sent to all remote servers')
             w(longOpt: 'worker', args: 0, argName: 'worker', 'Starts script in worker mode (will wait for controller to execute test)')
             c(longOpt: 'controller', args: 0, argName: 'controller', 'Starts script in controller mode (execute test on remote workers)')
             r(longOpt: 'remote-worker', args: 1, argName: 'hostname:port', 'Remote work address (hostname:port)')
@@ -83,10 +85,24 @@ abstract class TestScript extends TestScriptBase {
 
         script.no_run = options.'no-run'
         script.variables = [:]
+        script.local_properties = [:]
+        script.global_properties = [:]
 
         if (options.Vs) {
-            options.Vs.each { String name, String value ->
+            options.Vs.each { String name, Object value ->
                 script.variables[name] = value
+            }
+        }
+
+        if (options.Js) {
+            options.Js.each { String name, Object value ->
+                script.local_properties[name] = value
+            }
+        }
+
+        if (options.Gs) {
+            options.Gs.each { String name, Object value ->
+                script.global_properties[name] = value
             }
         }
 

--- a/src/main/groovy/net/simonix/dsl/jmeter/TestScriptBase.groovy
+++ b/src/main/groovy/net/simonix/dsl/jmeter/TestScriptBase.groovy
@@ -70,8 +70,24 @@ abstract class TestScriptBase extends Script {
         // add custom variables from command line
         config.variables = [:]
         if (script.variables) {
-            script.variables.each {
-                config.variables[it.key as String] = it.value
+            script.variables.each { String name, Object value ->
+                config.variables[name] = value
+            }
+        }
+
+        // add jmeter properties override from command line
+        config.local_properties = [:]
+        if (script.local_properties) {
+            script.local_properties.each { String name, Object value ->
+                config.local_properties[name] = value
+            }
+        }
+
+        // add global properties override from command line
+        config.global_properties = [:]
+        if (script.global_properties) {
+            script.global_properties.each { String name, Object value ->
+                config.global_properties[name] = value
             }
         }
 
@@ -87,7 +103,7 @@ abstract class TestScriptBase extends Script {
                 TestScriptServerRunner.run(script.worker_hostname as String, script.worker_port as String)
             } else if (script.controller) {
                 // controller server
-                TestScriptServerRunner.run(configuration, script.remote_workers as List<String>)
+                TestScriptServerRunner.run(configuration, config.global_properties, script.remote_workers as List<String>)
             } else {
                 // standard script execution
                 TestScriptRunner.run(configuration)

--- a/src/main/groovy/net/simonix/dsl/jmeter/TestScriptRunner.groovy
+++ b/src/main/groovy/net/simonix/dsl/jmeter/TestScriptRunner.groovy
@@ -88,6 +88,22 @@ final class TestScriptRunner {
             }
         }
 
+        if (config.local_properties) {
+            Properties properties = JMeterUtils.getJMeterProperties();
+
+            config.local_properties.each { String name, Object value ->
+                if(value) {
+                    if(value instanceof String && value.size() > 0) {
+                        properties.setProperty(name, value)
+                    } else {
+                        properties.remove(name)
+                    }
+                } else {
+                    properties.remove(name)
+                }
+            }
+        }
+
         JMeterUtils.initLocale()
 
         // we need to set jmeter libraries to search paths so functions can be picked up
@@ -113,8 +129,8 @@ final class TestScriptRunner {
         DefaultFactoryBuilder builder = new DefaultFactoryBuilder()
 
         if (config.variables) {
-            config.variables.each { entry ->
-                builder.setVariable(entry.key as String, entry.value)
+            config.variables.each { String name, Object value ->
+                builder.setVariable(name, value)
             }
         }
 
@@ -142,6 +158,7 @@ final class TestScriptRunner {
 
     static StatisticsProvider run(HashTree testPlan, boolean statistics = false) {
         StandardJMeterEngine engine = new StandardJMeterEngine()
+
 
         StatisticsListener listener = statistics ? applyStatistics(testPlan) : null
 

--- a/src/main/groovy/net/simonix/dsl/jmeter/TestScriptServerRunner.groovy
+++ b/src/main/groovy/net/simonix/dsl/jmeter/TestScriptServerRunner.groovy
@@ -61,7 +61,7 @@ class TestScriptServerRunner {
         }
     }
 
-    static void run(HashTree testPlan, List<String> remoteWorkers) {
+    static void run(HashTree testPlan, Map globalProperties, List<String> remoteWorkers) {
         System.setProperty('server.rmi.ssl.disable', 'true')  // TODO: enable SSL supports
 
         // add a system property so samplers can check to see if JMeter is running in NonGui mode
@@ -77,7 +77,12 @@ class TestScriptServerRunner {
             RemoteExecutionListener testListener = new RemoteExecutionListener(true)
             testPlan.add(testPlan.getArray()[0], testListener)
 
-            DistributedRunner distributedRunner = new DistributedRunner()
+            Properties properties = new Properties()
+            globalProperties.each { String name, Object value ->
+                properties.setProperty(name, value)
+            }
+
+            DistributedRunner distributedRunner = new DistributedRunner(properties)
 
             distributedRunner.init(remoteWorkers, testPlan)
             engines.addAll(distributedRunner.getEngines())

--- a/src/main/groovy/net/simonix/dsl/jmeter/factory/assertion/DurationAssertionFactory.groovy
+++ b/src/main/groovy/net/simonix/dsl/jmeter/factory/assertion/DurationAssertionFactory.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Szymon Micyk
+ * Copyright 2022 Szymon Micyk
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,7 +47,6 @@ final class DurationAssertionFactory extends TestElementNodeFactory {
 
     void updateTestElementProperties(TestElement testElement, Object name, Object value, Map config) {
         String applyTo = config.applyTo
-        Long duration = readValue(value, config.duration) as Long
 
         if (applyTo == 'all') {
             testElement.setScopeAll()
@@ -61,6 +60,6 @@ final class DurationAssertionFactory extends TestElementNodeFactory {
             testElement.setScopeAll()
         }
 
-        testElement.allowedDuration = duration
+        testElement.setProperty(DurationAssertion.DURATION_KEY, readValue(value, config.duration))
     }
 }

--- a/src/main/groovy/net/simonix/dsl/jmeter/factory/assertion/SizeAssertionFactory.groovy
+++ b/src/main/groovy/net/simonix/dsl/jmeter/factory/assertion/SizeAssertionFactory.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Szymon Micyk
+ * Copyright 2022 Szymon Micyk
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,7 +53,6 @@ final class SizeAssertionFactory extends TestElementNodeFactory {
         String variableName = config.variable
         String field = config.field
         String rule = config.rule
-        Long size = readValue(value, config.size)
 
         if (applyTo == 'all') {
             testElement.setScopeAll()
@@ -97,6 +96,6 @@ final class SizeAssertionFactory extends TestElementNodeFactory {
             testElement.setCompOper(SizeAssertion.EQUAL)
         }
 
-        testElement.allowedSize = size
+        testElement.setAllowedSize(readValue(value, config.size))
     }
 }

--- a/src/main/groovy/net/simonix/dsl/jmeter/factory/config/DefaultsFactory.groovy
+++ b/src/main/groovy/net/simonix/dsl/jmeter/factory/config/DefaultsFactory.groovy
@@ -72,7 +72,7 @@ final class DefaultsFactory extends TestElementNodeFactory {
         // Web Server configuration
         testElement.setProperty(HTTPSampler.PROTOCOL, config.protocol as String)
         testElement.setProperty(HTTPSampler.DOMAIN, config.domain as String)
-        testElement.setProperty(HTTPSampler.PORT, config.port as Integer)
+        testElement.setProperty(HTTPSampler.PORT, config.port as String)
 
         // Request configuration
         testElement.setProperty(HTTPSampler.METHOD, config.method as String)

--- a/src/main/groovy/net/simonix/dsl/jmeter/factory/controller/LoopFactory.groovy
+++ b/src/main/groovy/net/simonix/dsl/jmeter/factory/controller/LoopFactory.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Szymon Micyk
+ * Copyright 2022 Szymon Micyk
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,9 +50,9 @@ final class LoopFactory extends TestElementNodeFactory {
     }
 
     void updateTestElementProperties(TestElement testElement, Object name, Object value, Map config) {
-        Integer count = config.count as Integer
+        Object count = config.count
 
-        if (value instanceof Integer) {
+        if (value) {
             count = value
         }
 

--- a/src/main/groovy/net/simonix/dsl/jmeter/factory/controller/execution/PercentControllerFactory.groovy
+++ b/src/main/groovy/net/simonix/dsl/jmeter/factory/controller/execution/PercentControllerFactory.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Szymon Micyk
+ * Copyright 2022 Szymon Micyk
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,11 +49,9 @@ final class PercentControllerFactory extends TestElementNodeFactory {
     }
 
     void updateTestElementProperties(TestElement testElement, Object name, Object value, Map config) {
-        Integer percent = readValue(value, config.percent) as Integer
-
         testElement.style = ThroughputController.BYPERCENT
         testElement.perThread = config.perUser
         testElement.maxThroughput = 1
-        testElement.percentThroughput = percent
+        testElement.percentThroughput = readValue(value, config.percent)
     }
 }

--- a/src/main/groovy/net/simonix/dsl/jmeter/factory/controller/execution/TotalControllerFactory.groovy
+++ b/src/main/groovy/net/simonix/dsl/jmeter/factory/controller/execution/TotalControllerFactory.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Szymon Micyk
+ * Copyright 2022 Szymon Micyk
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,11 +50,10 @@ final class TotalControllerFactory extends TestElementNodeFactory {
 
     void updateTestElementProperties(TestElement testElement, Object name, Object value, Map config) {
         boolean perUser = config.perUser
-        Integer total = readValue(value, config.total) as Integer
 
         testElement.style = ThroughputController.BYNUMBER
         testElement.perThread = perUser
-        testElement.maxThroughput = total
+        testElement.maxThroughput = readValue(value, config.total)
         testElement.percentThroughput = 100
     }
 }

--- a/src/main/groovy/net/simonix/dsl/jmeter/factory/group/GroupFactory.groovy
+++ b/src/main/groovy/net/simonix/dsl/jmeter/factory/group/GroupFactory.groovy
@@ -26,8 +26,6 @@ import org.apache.jmeter.threads.gui.ThreadGroupGui
 
 import net.simonix.dsl.jmeter.factory.TestElementNodeFactory
 
-import static net.simonix.dsl.jmeter.utils.ConfigUtils.readValue
-
 /**
  * The factory class responsible for building <code>group</code> element in the test.
  *
@@ -73,15 +71,17 @@ final class GroupFactory extends TestElementNodeFactory {
     void updateTestElementProperties(TestElement testElement, Object name, Object value, Map config) {
         testElement.setProperty(AbstractThreadGroup.ON_SAMPLE_ERROR, mapOnError(config.onError))
 
-        testElement.numThreads = config.users as Integer
-        testElement.rampUp = config.rampUp as Integer
+        testElement.setProperty(AbstractThreadGroup.NUM_THREADS, config.users)
+        testElement.setProperty(ThreadGroup.RAMP_TIME, config.rampUp)
+
         testElement.setProperty(ThreadGroup.DELAYED_START, config.delayedStart as Boolean)
         testElement.isSameUserOnNextIteration = config.keepUser
 
+
         // scheduler configuration
         testElement.scheduler = config.scheduler
-        testElement.delay = config.delay
-        testElement.duration = config.duration
+        testElement.setProperty(ThreadGroup.DURATION, config.delay)
+        testElement.setProperty(ThreadGroup.DELAY, config.duration)
 
         // set default controller as loop (that seems to be jmeter defaults)
         LoopController defaultLoopController = new LoopController()

--- a/src/main/groovy/net/simonix/dsl/jmeter/factory/group/PostGroupFactory.groovy
+++ b/src/main/groovy/net/simonix/dsl/jmeter/factory/group/PostGroupFactory.groovy
@@ -70,14 +70,14 @@ final class PostGroupFactory extends TestElementNodeFactory {
     void updateTestElementProperties(TestElement testElement, Object name, Object value, Map config) {
         testElement.setProperty(AbstractThreadGroup.ON_SAMPLE_ERROR, mapOnError(config.onError))
 
-        testElement.numThreads = config.users as Integer
-        testElement.rampUp = config.rampUp as Integer
+        testElement.setProperty(AbstractThreadGroup.NUM_THREADS, config.users)
+        testElement.setProperty(ThreadGroup.RAMP_TIME, config.rampUp)
         testElement.isSameUserOnNextIteration = config.keepUser
 
         // scheduler configuration
         testElement.scheduler = config.scheduler
-        testElement.delay = config.delay
-        testElement.duration = config.duration
+        testElement.setProperty(ThreadGroup.DURATION, config.delay)
+        testElement.setProperty(ThreadGroup.DELAY, config.duration)
 
         // set default controller as loop (that seems to be jmeter defaults)
         LoopController defaultLoopController = new LoopController()

--- a/src/main/groovy/net/simonix/dsl/jmeter/factory/group/PreGroupFactory.groovy
+++ b/src/main/groovy/net/simonix/dsl/jmeter/factory/group/PreGroupFactory.groovy
@@ -70,14 +70,14 @@ final class PreGroupFactory extends TestElementNodeFactory {
     void updateTestElementProperties(TestElement testElement, Object name, Object value, Map config) {
         testElement.setProperty(AbstractThreadGroup.ON_SAMPLE_ERROR, mapOnError(config.onError))
 
-        testElement.numThreads = config.users as Integer
-        testElement.rampUp = config.rampUp as Integer
+        testElement.setProperty(AbstractThreadGroup.NUM_THREADS, config.users)
+        testElement.setProperty(ThreadGroup.RAMP_TIME, config.rampUp)
         testElement.isSameUserOnNextIteration = config.keepUser
 
         // scheduler configuration
         testElement.scheduler = config.scheduler
-        testElement.delay = config.delay
-        testElement.duration = config.duration
+        testElement.setProperty(ThreadGroup.DURATION, config.delay)
+        testElement.setProperty(ThreadGroup.DELAY, config.duration)
 
         // set default controller as loop (that seems to be jmeter defaults)
         LoopController defaultLoopController = new LoopController()

--- a/src/main/groovy/net/simonix/dsl/jmeter/factory/sampler/BaseHttpFactory.groovy
+++ b/src/main/groovy/net/simonix/dsl/jmeter/factory/sampler/BaseHttpFactory.groovy
@@ -18,7 +18,7 @@ package net.simonix.dsl.jmeter.factory.sampler
 import groovy.transform.CompileDynamic
 import net.simonix.dsl.jmeter.factory.TestElementNodeFactory
 import net.simonix.dsl.jmeter.model.definition.KeywordDefinition
-import org.apache.jmeter.protocol.http.sampler.HTTPSamplerProxy
+import org.apache.jmeter.protocol.http.sampler.HTTPSamplerBase
 import org.apache.jmeter.protocol.http.util.HTTPConstants
 import org.apache.jmeter.testelement.TestElement
 
@@ -65,9 +65,9 @@ abstract class BaseHttpFactory extends TestElementNodeFactory {
         String domain = config.domain
         String path = config.path
 
-        Integer port = null
+        String port = null
         if (config.containsKey('port')) {
-            port = config.port as Integer
+            port = config.port
         }
 
         // override config elements
@@ -80,7 +80,7 @@ abstract class BaseHttpFactory extends TestElementNodeFactory {
                 protocol = matches.group('protocol') ?: protocol
                 domain = matches.group('domain') ?: domain
                 if (matches.group('port')) {
-                    port = matches.group('port').toInteger()
+                    port = matches.group('port')
                 }
                 path = matches.group('path') ?: path
 
@@ -96,7 +96,7 @@ abstract class BaseHttpFactory extends TestElementNodeFactory {
         testElement.domain = domain
 
         if (port != null) {
-            testElement.port = port
+            testElement.setProperty(HTTPSamplerBase.PORT, port);
         }
 
         // Request configuration
@@ -125,7 +125,7 @@ abstract class BaseHttpFactory extends TestElementNodeFactory {
         return [ URL_PATH, URL_PORT, URL_HOSTNAME, URL_PROTOCOL, URL_PROTOCOL_WITHOUT_PORT, URL_HOSTNAME_WITHOUT_PORT]
     }
 
-    private static String evaluateElementName(String method, String protocol, String domain, Integer port, String path) {
+    private static String evaluateElementName(String method, String protocol, String domain, String port, String path) {
         String elementName = "${method} ${path?:'/'}"
 
         return elementName.replaceAll(/(\$\{(.*?)\})/) { input, expression, variable -> ":$variable" }

--- a/src/main/groovy/net/simonix/dsl/jmeter/factory/timer/ConstantThroughputFactory.groovy
+++ b/src/main/groovy/net/simonix/dsl/jmeter/factory/timer/ConstantThroughputFactory.groovy
@@ -57,11 +57,8 @@ final class ConstantThroughputFactory extends TestElementNodeFactory {
     void updateTestElementProperties(TestElement testElement, Object name, Object value, Map config) {
         int basedOn = mapBasedOn(config.basedOn as String)
 
-        testElement.calcMode = basedOn
-        testElement.throughput = config.target
-
         testElement.setProperty('calcMode', basedOn)
-        testElement.setProperty(new DoubleProperty('throughput', config.target as Double))
+        testElement.setProperty('throughput', config.target as String)
     }
 
     private int mapBasedOn(String value) {

--- a/src/main/groovy/net/simonix/dsl/jmeter/factory/timer/PreciseThroughputFactory.groovy
+++ b/src/main/groovy/net/simonix/dsl/jmeter/factory/timer/PreciseThroughputFactory.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Szymon Micyk
+ * Copyright 2022 Szymon Micyk
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,28 +61,16 @@ final class PreciseThroughputFactory extends TestElementNodeFactory {
     }
 
     void updateTestElementProperties(TestElement testElement, Object name, Object value, Map config) {
-        testElement.throughput = config.target
-        testElement.throughputPeriod = config.period
-        testElement.duration = config.duration
+        testElement.setProperty('throughput', config.target as String)
+        testElement.setProperty('throughputPeriod', config.period)
+        testElement.setProperty('duration', config.duration)
 
-        testElement.batchSize = config.batchUsers
-        testElement.batchThreadDelay = config.batchDelay
+        testElement.setProperty('batchSize', config.batchUsers)
+        testElement.setProperty('batchThreadDelay', config.batchDelay)
 
-        testElement.exactLimit = config.samples
-        testElement.allowedThroughputSurplus = config.percents
+        testElement.setProperty('exactLimit', config.samples)
+        testElement.setProperty('allowedThroughputSurplus', config.batchDelay as String)
 
-        testElement.randomSeed = config.seed
-
-        testElement.setProperty(new DoubleProperty('throughput', config.target as Double))
-        testElement.setProperty('throughputPeriod', config.period as Integer)
-        testElement.setProperty('duration', config.duration as Long)
-
-        testElement.setProperty('batchSize', config.batchUsers as Integer)
-        testElement.setProperty('batchThreadDelay', config.batchDelay as Integer)
-
-        testElement.setProperty('exactLimit', config.samples as Integer)
-        testElement.setProperty(new DoubleProperty('allowedThroughputSurplus', config.percents as Double))
-
-        testElement.setProperty('randomSeed', config.seed as Long)
+        testElement.setProperty('randomSeed', config.seed)
     }
 }

--- a/src/main/groovy/net/simonix/dsl/jmeter/factory/timer/SynchronizingTimerFactory.groovy
+++ b/src/main/groovy/net/simonix/dsl/jmeter/factory/timer/SynchronizingTimerFactory.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Szymon Micyk
+ * Copyright 2022 Szymon Micyk
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,10 +54,7 @@ final class SynchronizingTimerFactory extends TestElementNodeFactory {
     }
 
     void updateTestElementProperties(TestElement testElement, Object name, Object value, Map config) {
-        testElement.groupSize = config.users
-        testElement.timeoutInMs = config.timeout
-
-        testElement.setProperty('groupSize', config.users as Integer)
-        testElement.setProperty('timeoutInMs', config.timeout as Long)
+        testElement.setProperty('groupSize', config.users)
+        testElement.setProperty('timeoutInMs', config.timeout)
     }
 }

--- a/src/main/groovy/net/simonix/dsl/jmeter/model/constraint/InListPropertyConstraint.groovy
+++ b/src/main/groovy/net/simonix/dsl/jmeter/model/constraint/InListPropertyConstraint.groovy
@@ -26,6 +26,13 @@ class InListPropertyConstraint implements PropertyConstraint {
 
     @Override
     boolean matches(Object value) {
+        if(value instanceof String) {
+            // check if is expression, if yes just pass it as string with out validation
+            if(value.startsWith('${') && value.endsWith('}')) {
+                return true
+            }
+        }
+
         return values.contains(value)
     }
 

--- a/src/main/groovy/net/simonix/dsl/jmeter/model/constraint/RangePropertyConstraint.groovy
+++ b/src/main/groovy/net/simonix/dsl/jmeter/model/constraint/RangePropertyConstraint.groovy
@@ -58,10 +58,16 @@ class RangePropertyConstraint implements PropertyConstraint {
                     bigint.compareTo(BigInteger.valueOf(to)) <= 0
         }
         if (value instanceof String) {
-            Long convertedValue = value.asType(Long)
+            // check if is expression, if yes just pass it as string with out validation
+            if(value.startsWith('${') && value.endsWith('}')) {
+                return true
+            } else {
+                Long convertedValue = value as Long
 
-            return convertedValue >= from && convertedValue <= to
+                return convertedValue >= from && convertedValue <= to
+            }
         }
+
         return false
     }
 }

--- a/src/test/groovy/net/simonix/dsl/jmeter/factory/group/GroupFactorySpec.groovy
+++ b/src/test/groovy/net/simonix/dsl/jmeter/factory/group/GroupFactorySpec.groovy
@@ -59,4 +59,33 @@ class GroupFactorySpec extends TempFileSpec {
         then: 'both files matches'
         filesAreTheSame('group_1.jmx', resultFile)
     }
+
+    def "Check group generation with expression"() {
+        given: 'Test plan with group element'
+        def config = configure {
+            plan {
+                variables values: [
+                        'var_users': 10,
+                        'var_rampUp': 60,
+                        'var_delay': 10,
+                        'var_delayedStart': 10,
+                        'var_duration': 10,
+                        'var_loops': 2,
+                        'var_onError': 'stop_test'
+                ]
+
+                before(users: '${var_users}', rampUp: '${var_rampUp}', scheduler: true, delay: '${var_delay}', duration: '${var_duration}', loops: '${var_loops}', forever: true, onError: '${var_onError}', keepUser: false)
+                group(users: '${var_users}', rampUp: '${var_delay}', delayedStart: '${var_delayedStart}', scheduler: true, delay: '${var_delay}', duration: '${var_duration}', loops: '${var_loops}', forever: true, onError: '${var_onError}', keepUser: false)
+                after(users: '${var_users}', rampUp: '${var_duration}', scheduler: true, delay: '${var_delay}', duration: '${var_duration}', loops: '${var_loops}', forever: true, onError: 'stop_test', keepUser: false)
+            }
+        }
+
+        File resultFile = tempFolder.newFile('group_2.jmx')
+
+        when: 'save test to file'
+        save(config, resultFile)
+
+        then: 'both files matches'
+        filesAreTheSame('group_2.jmx', resultFile)
+    }
 }

--- a/src/test/groovy/net/simonix/dsl/jmeter/factory/timer/TimerFactorySpec.groovy
+++ b/src/test/groovy/net/simonix/dsl/jmeter/factory/timer/TimerFactorySpec.groovy
@@ -106,4 +106,51 @@ class TimerFactorySpec extends TempFileSpec {
         then: 'both files matches'
         filesAreTheSame('timers_2.jmx', resultFile)
     }
+
+    def "Check timers generation with expressions"() {
+        given: 'Test plan with timers element'
+        def config = configure {
+            plan {
+                // variables
+                variables values: [
+                        'var_delay': 500,
+                        'var_range': 1000,
+
+                        'var_target': 200,
+                        'var_basedOn': 'all_users',
+
+                        'var_period': 1000,
+                        'var_duration': 1000,
+                        'var_batchUsers': 10,
+                        'var_batchDelay': 10,
+                        'var_samples': 1000,
+                        'var_percent': 50,
+                        'var_seed': 100000,
+
+                        'var_users': 100,
+                        'var_timeout': 1000
+                ]
+                // random timers
+                constant_timer(delay: '${var_delay}')
+                uniform_timer(delay: '${var_delay}', range: '${var_range}')
+                poisson_timer(delay: '${var_delay}', range: '${var_range}')
+                gaussian_timer(delay: '${var_delay}', range: '${var_range}')
+
+                // throughput
+                constant_throughput(target: '${var_target}', basedOn: '${var_basedOn}')
+                precise_throughput(target: '${var_target}', period: '${var_period}', duration: '${var_duration}', batchUsers: '${var_batchUsers}', batchDelay: '${var_batchDelay}', samples: '${var_samples}', percents: '${var_percent}', seed: '${var_seed}')
+
+                // synchronizing
+                synchronizing_timer(users: '${var_users}', timeout: '${var_timeout}')
+            }
+        }
+
+        File resultFile = tempFolder.newFile('timers_3.jmx')
+
+        when: 'save test to file'
+        save(config, resultFile)
+
+        then: 'both files matches'
+        filesAreTheSame('timers_3.jmx', resultFile)
+    }
 }

--- a/src/test/groovy/net/simonix/dsl/jmeter/model/constraint/InListConstraintSpec.groovy
+++ b/src/test/groovy/net/simonix/dsl/jmeter/model/constraint/InListConstraintSpec.groovy
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 Szymon Micyk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.simonix.dsl.jmeter.model.constraint
+
+import spock.lang.Specification
+
+class InListConstraintSpec extends Specification  {
+
+    def "matches range with numbers"() {
+        given:
+        InListPropertyConstraint constraint = Constraints.inList(['value1', 'value2'])
+
+        expect:
+        constraint.matches(value) == result
+
+        where:
+        value        || result
+        'value1'     || true
+        'value2'     || true
+        'value3'     || false
+    }
+
+    def "matches range with expression"() {
+        given:
+        InListPropertyConstraint constraint = Constraints.inList(['value1', 'value2'])
+
+        expect:
+        constraint.matches(value) == result
+
+        where:
+        value              || result
+        'value1'           || true
+        'value2'           || true
+        '${var_value}'     || true
+    }
+}

--- a/src/test/groovy/net/simonix/dsl/jmeter/model/constraint/RangePropertyConstraintSpec.groovy
+++ b/src/test/groovy/net/simonix/dsl/jmeter/model/constraint/RangePropertyConstraintSpec.groovy
@@ -72,4 +72,17 @@ class RangePropertyConstraintSpec extends Specification  {
         '20'    || false
         '-20'   || false
     }
+
+    def "matches range with String with expression"() {
+        given:
+        RangePropertyConstraint constraint = Constraints.range(-10, 10)
+
+        expect:
+        constraint.matches(value) == result
+
+        where:
+        value               || result
+        '0'                 || true
+        '${var_value}'      || true
+    }
 }

--- a/src/test/resources/net/simonix/dsl/jmeter/factory/assertion/assertions_0.jmx
+++ b/src/test/resources/net/simonix/dsl/jmeter/factory/assertion/assertions_0.jmx
@@ -36,8 +36,8 @@
         <boolProp name="ThreadGroup.delayedStart">false</boolProp>
         <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
         <boolProp name="ThreadGroup.scheduler">false</boolProp>
-        <longProp name="ThreadGroup.delay">0</longProp>
-        <longProp name="ThreadGroup.duration">0</longProp>
+        <intProp name="ThreadGroup.duration">0</intProp>
+        <intProp name="ThreadGroup.delay">0</intProp>
         <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" enabled="true">
           <boolProp name="LoopController.continue_forever">false</boolProp>
           <intProp name="LoopController.loops">1</intProp>
@@ -67,17 +67,17 @@
         <hashTree/>
         <DurationAssertion guiclass="DurationAssertionGui" testclass="DurationAssertion" testname="Duration Assertion" enabled="true">
           <stringProp name="Assertion.scope">all</stringProp>
-          <longProp name="DurationAssertion.duration">10</longProp>
+          <intProp name="DurationAssertion.duration">10</intProp>
         </DurationAssertion>
         <hashTree/>
         <DurationAssertion guiclass="DurationAssertionGui" testclass="DurationAssertion" testname="Assert Duration Factory" enabled="true">
           <stringProp name="TestPlan.comments">Factory Comments</stringProp>
-          <longProp name="DurationAssertion.duration">10</longProp>
+          <intProp name="DurationAssertion.duration">10</intProp>
         </DurationAssertion>
         <hashTree/>
         <DurationAssertion guiclass="DurationAssertionGui" testclass="DurationAssertion" testname="Duration Assertion" enabled="true">
           <stringProp name="Assertion.scope">all</stringProp>
-          <longProp name="DurationAssertion.duration">10</longProp>
+          <intProp name="DurationAssertion.duration">10</intProp>
         </DurationAssertion>
         <hashTree/>
         <JSONPathAssertion guiclass="JSONPathAssertionGui" testclass="JSONPathAssertion" testname="Json Path Assertion" enabled="true">

--- a/src/test/resources/net/simonix/dsl/jmeter/factory/assertion/assertions_1.jmx
+++ b/src/test/resources/net/simonix/dsl/jmeter/factory/assertion/assertions_1.jmx
@@ -36,8 +36,8 @@
         <boolProp name="ThreadGroup.delayedStart">false</boolProp>
         <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
         <boolProp name="ThreadGroup.scheduler">false</boolProp>
-        <longProp name="ThreadGroup.delay">0</longProp>
-        <longProp name="ThreadGroup.duration">0</longProp>
+        <intProp name="ThreadGroup.duration">0</intProp>
+        <intProp name="ThreadGroup.delay">0</intProp>
         <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" enabled="true">
           <boolProp name="LoopController.continue_forever">false</boolProp>
           <intProp name="LoopController.loops">1</intProp>

--- a/src/test/resources/net/simonix/dsl/jmeter/factory/common/insert_0.jmx
+++ b/src/test/resources/net/simonix/dsl/jmeter/factory/common/insert_0.jmx
@@ -36,8 +36,8 @@
         <boolProp name="ThreadGroup.delayedStart">false</boolProp>
         <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
         <boolProp name="ThreadGroup.scheduler">false</boolProp>
-        <longProp name="ThreadGroup.delay">0</longProp>
-        <longProp name="ThreadGroup.duration">0</longProp>
+        <intProp name="ThreadGroup.duration">0</intProp>
+        <intProp name="ThreadGroup.delay">0</intProp>
         <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" enabled="true">
           <boolProp name="LoopController.continue_forever">false</boolProp>
           <intProp name="LoopController.loops">1</intProp>

--- a/src/test/resources/net/simonix/dsl/jmeter/factory/common/shorts_0.jmx
+++ b/src/test/resources/net/simonix/dsl/jmeter/factory/common/shorts_0.jmx
@@ -36,8 +36,8 @@
         <boolProp name="ThreadGroup.delayedStart">false</boolProp>
         <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
         <boolProp name="ThreadGroup.scheduler">false</boolProp>
-        <longProp name="ThreadGroup.delay">0</longProp>
-        <longProp name="ThreadGroup.duration">0</longProp>
+        <intProp name="ThreadGroup.duration">0</intProp>
+        <intProp name="ThreadGroup.delay">0</intProp>
         <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" enabled="true">
           <boolProp name="LoopController.continue_forever">false</boolProp>
           <intProp name="LoopController.loops">1</intProp>
@@ -47,7 +47,7 @@
         <ConfigTestElement guiclass="HttpDefaultsGui" testclass="ConfigTestElement" testname="HTTP Request Defaults" enabled="true">
           <stringProp name="HTTPSampler.protocol">http</stringProp>
           <stringProp name="HTTPSampler.domain">localhost</stringProp>
-          <intProp name="HTTPSampler.port">80</intProp>
+          <stringProp name="HTTPSampler.port">80</stringProp>
           <stringProp name="HTTPSampler.method">GET</stringProp>
           <stringProp name="HTTPSampler.path"></stringProp>
           <stringProp name="HTTPSampler.contentEncoding"></stringProp>

--- a/src/test/resources/net/simonix/dsl/jmeter/factory/config/defaults_0.jmx
+++ b/src/test/resources/net/simonix/dsl/jmeter/factory/config/defaults_0.jmx
@@ -33,7 +33,7 @@
         <stringProp name="TestPlan.comments">Factory Comment</stringProp>
         <stringProp name="HTTPSampler.protocol">https</stringProp>
         <stringProp name="HTTPSampler.domain">localhost</stringProp>
-        <intProp name="HTTPSampler.port">8080</intProp>
+        <stringProp name="HTTPSampler.port">8080</stringProp>
         <stringProp name="HTTPSampler.method">POST</stringProp>
         <stringProp name="HTTPSampler.path">/context</stringProp>
         <stringProp name="HTTPSampler.contentEncoding">UTF-8</stringProp>
@@ -46,7 +46,7 @@
       <ConfigTestElement guiclass="HttpDefaultsGui" testclass="ConfigTestElement" testname="HTTP Request Defaults" enabled="true">
         <stringProp name="HTTPSampler.protocol">http</stringProp>
         <stringProp name="HTTPSampler.domain"></stringProp>
-        <intProp name="HTTPSampler.port">80</intProp>
+        <stringProp name="HTTPSampler.port">80</stringProp>
         <stringProp name="HTTPSampler.method">GET</stringProp>
         <stringProp name="HTTPSampler.path"></stringProp>
         <stringProp name="HTTPSampler.contentEncoding"></stringProp>
@@ -59,7 +59,7 @@
       <ConfigTestElement guiclass="HttpDefaultsGui" testclass="ConfigTestElement" testname="HTTP Request Defaults" enabled="true">
         <stringProp name="HTTPSampler.protocol">http</stringProp>
         <stringProp name="HTTPSampler.domain"></stringProp>
-        <intProp name="HTTPSampler.port">80</intProp>
+        <stringProp name="HTTPSampler.port">80</stringProp>
         <stringProp name="HTTPSampler.method">GET</stringProp>
         <stringProp name="HTTPSampler.path"></stringProp>
         <stringProp name="HTTPSampler.contentEncoding"></stringProp>

--- a/src/test/resources/net/simonix/dsl/jmeter/factory/config/defaults_1.jmx
+++ b/src/test/resources/net/simonix/dsl/jmeter/factory/config/defaults_1.jmx
@@ -32,7 +32,7 @@
       <ConfigTestElement guiclass="HttpDefaultsGui" testclass="ConfigTestElement" testname="HTTP Request Defaults" enabled="true">
         <stringProp name="HTTPSampler.protocol">http</stringProp>
         <stringProp name="HTTPSampler.domain"></stringProp>
-        <intProp name="HTTPSampler.port">80</intProp>
+        <stringProp name="HTTPSampler.port">80</stringProp>
         <stringProp name="HTTPSampler.method">GET</stringProp>
         <stringProp name="HTTPSampler.path"></stringProp>
         <stringProp name="HTTPSampler.contentEncoding"></stringProp>

--- a/src/test/resources/net/simonix/dsl/jmeter/factory/config/defaults_2.jmx
+++ b/src/test/resources/net/simonix/dsl/jmeter/factory/config/defaults_2.jmx
@@ -32,7 +32,7 @@
       <ConfigTestElement guiclass="HttpDefaultsGui" testclass="ConfigTestElement" testname="HTTP Request Defaults" enabled="true">
         <stringProp name="HTTPSampler.protocol">http</stringProp>
         <stringProp name="HTTPSampler.domain"></stringProp>
-        <intProp name="HTTPSampler.port">80</intProp>
+        <stringProp name="HTTPSampler.port">80</stringProp>
         <stringProp name="HTTPSampler.method">GET</stringProp>
         <stringProp name="HTTPSampler.path"></stringProp>
         <stringProp name="HTTPSampler.contentEncoding"></stringProp>

--- a/src/test/resources/net/simonix/dsl/jmeter/factory/config/defaults_3.jmx
+++ b/src/test/resources/net/simonix/dsl/jmeter/factory/config/defaults_3.jmx
@@ -32,7 +32,7 @@
       <ConfigTestElement guiclass="HttpDefaultsGui" testclass="ConfigTestElement" testname="HTTP Request Defaults" enabled="true">
         <stringProp name="HTTPSampler.protocol">http</stringProp>
         <stringProp name="HTTPSampler.domain"></stringProp>
-        <intProp name="HTTPSampler.port">80</intProp>
+        <stringProp name="HTTPSampler.port">80</stringProp>
         <stringProp name="HTTPSampler.method">GET</stringProp>
         <stringProp name="HTTPSampler.path"></stringProp>
         <stringProp name="HTTPSampler.contentEncoding"></stringProp>

--- a/src/test/resources/net/simonix/dsl/jmeter/factory/config/defaults_4.jmx
+++ b/src/test/resources/net/simonix/dsl/jmeter/factory/config/defaults_4.jmx
@@ -32,7 +32,7 @@
       <ConfigTestElement guiclass="HttpDefaultsGui" testclass="ConfigTestElement" testname="HTTP Request Defaults" enabled="true">
         <stringProp name="HTTPSampler.protocol">http</stringProp>
         <stringProp name="HTTPSampler.domain"></stringProp>
-        <intProp name="HTTPSampler.port">80</intProp>
+        <stringProp name="HTTPSampler.port">80</stringProp>
         <stringProp name="HTTPSampler.method">GET</stringProp>
         <stringProp name="HTTPSampler.path"></stringProp>
         <stringProp name="HTTPSampler.contentEncoding"></stringProp>

--- a/src/test/resources/net/simonix/dsl/jmeter/factory/config/jdbc_0.jmx
+++ b/src/test/resources/net/simonix/dsl/jmeter/factory/config/jdbc_0.jmx
@@ -36,8 +36,8 @@
         <boolProp name="ThreadGroup.delayedStart">false</boolProp>
         <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
         <boolProp name="ThreadGroup.scheduler">false</boolProp>
-        <longProp name="ThreadGroup.delay">0</longProp>
-        <longProp name="ThreadGroup.duration">0</longProp>
+        <intProp name="ThreadGroup.duration">0</intProp>
+        <intProp name="ThreadGroup.delay">0</intProp>
         <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" enabled="true">
           <boolProp name="LoopController.continue_forever">false</boolProp>
           <intProp name="LoopController.loops">1</intProp>

--- a/src/test/resources/net/simonix/dsl/jmeter/factory/controller/controllers_0.jmx
+++ b/src/test/resources/net/simonix/dsl/jmeter/factory/controller/controllers_0.jmx
@@ -36,8 +36,8 @@
         <boolProp name="ThreadGroup.delayedStart">false</boolProp>
         <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
         <boolProp name="ThreadGroup.scheduler">false</boolProp>
-        <longProp name="ThreadGroup.delay">0</longProp>
-        <longProp name="ThreadGroup.duration">0</longProp>
+        <intProp name="ThreadGroup.duration">0</intProp>
+        <intProp name="ThreadGroup.delay">0</intProp>
         <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" enabled="true">
           <boolProp name="LoopController.continue_forever">false</boolProp>
           <intProp name="LoopController.loops">1</intProp>

--- a/src/test/resources/net/simonix/dsl/jmeter/factory/controller/controllers_1.jmx
+++ b/src/test/resources/net/simonix/dsl/jmeter/factory/controller/controllers_1.jmx
@@ -36,8 +36,8 @@
         <boolProp name="ThreadGroup.delayedStart">false</boolProp>
         <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
         <boolProp name="ThreadGroup.scheduler">false</boolProp>
-        <longProp name="ThreadGroup.delay">0</longProp>
-        <longProp name="ThreadGroup.duration">0</longProp>
+        <intProp name="ThreadGroup.duration">0</intProp>
+        <intProp name="ThreadGroup.delay">0</intProp>
         <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" enabled="true">
           <boolProp name="LoopController.continue_forever">false</boolProp>
           <intProp name="LoopController.loops">1</intProp>

--- a/src/test/resources/net/simonix/dsl/jmeter/factory/group/group_0.jmx
+++ b/src/test/resources/net/simonix/dsl/jmeter/factory/group/group_0.jmx
@@ -36,8 +36,8 @@
         <intProp name="ThreadGroup.ramp_time">60</intProp>
         <boolProp name="ThreadGroup.same_user_on_next_iteration">false</boolProp>
         <boolProp name="ThreadGroup.scheduler">true</boolProp>
-        <longProp name="ThreadGroup.delay">10</longProp>
-        <longProp name="ThreadGroup.duration">10</longProp>
+        <intProp name="ThreadGroup.duration">10</intProp>
+        <intProp name="ThreadGroup.delay">10</intProp>
         <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" enabled="true">
           <boolProp name="LoopController.continue_forever">false</boolProp>
           <intProp name="LoopController.loops">2</intProp>
@@ -52,8 +52,8 @@
         <boolProp name="ThreadGroup.delayedStart">true</boolProp>
         <boolProp name="ThreadGroup.same_user_on_next_iteration">false</boolProp>
         <boolProp name="ThreadGroup.scheduler">true</boolProp>
-        <longProp name="ThreadGroup.delay">10</longProp>
-        <longProp name="ThreadGroup.duration">10</longProp>
+        <intProp name="ThreadGroup.duration">10</intProp>
+        <intProp name="ThreadGroup.delay">10</intProp>
         <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" enabled="true">
           <boolProp name="LoopController.continue_forever">false</boolProp>
           <intProp name="LoopController.loops">2</intProp>
@@ -67,8 +67,8 @@
         <intProp name="ThreadGroup.ramp_time">60</intProp>
         <boolProp name="ThreadGroup.same_user_on_next_iteration">false</boolProp>
         <boolProp name="ThreadGroup.scheduler">true</boolProp>
-        <longProp name="ThreadGroup.delay">10</longProp>
-        <longProp name="ThreadGroup.duration">10</longProp>
+        <intProp name="ThreadGroup.duration">10</intProp>
+        <intProp name="ThreadGroup.delay">10</intProp>
         <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" enabled="true">
           <boolProp name="LoopController.continue_forever">false</boolProp>
           <intProp name="LoopController.loops">2</intProp>

--- a/src/test/resources/net/simonix/dsl/jmeter/factory/group/group_1.jmx
+++ b/src/test/resources/net/simonix/dsl/jmeter/factory/group/group_1.jmx
@@ -35,8 +35,8 @@
         <intProp name="ThreadGroup.ramp_time">1</intProp>
         <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
         <boolProp name="ThreadGroup.scheduler">false</boolProp>
-        <longProp name="ThreadGroup.delay">0</longProp>
-        <longProp name="ThreadGroup.duration">0</longProp>
+        <intProp name="ThreadGroup.duration">0</intProp>
+        <intProp name="ThreadGroup.delay">0</intProp>
         <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" enabled="true">
           <boolProp name="LoopController.continue_forever">false</boolProp>
           <intProp name="LoopController.loops">1</intProp>
@@ -50,8 +50,8 @@
         <boolProp name="ThreadGroup.delayedStart">false</boolProp>
         <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
         <boolProp name="ThreadGroup.scheduler">false</boolProp>
-        <longProp name="ThreadGroup.delay">0</longProp>
-        <longProp name="ThreadGroup.duration">0</longProp>
+        <intProp name="ThreadGroup.duration">0</intProp>
+        <intProp name="ThreadGroup.delay">0</intProp>
         <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" enabled="true">
           <boolProp name="LoopController.continue_forever">false</boolProp>
           <intProp name="LoopController.loops">1</intProp>
@@ -64,8 +64,8 @@
         <intProp name="ThreadGroup.ramp_time">1</intProp>
         <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
         <boolProp name="ThreadGroup.scheduler">false</boolProp>
-        <longProp name="ThreadGroup.delay">0</longProp>
-        <longProp name="ThreadGroup.duration">0</longProp>
+        <intProp name="ThreadGroup.duration">0</intProp>
+        <intProp name="ThreadGroup.delay">0</intProp>
         <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" enabled="true">
           <boolProp name="LoopController.continue_forever">false</boolProp>
           <intProp name="LoopController.loops">1</intProp>

--- a/src/test/resources/net/simonix/dsl/jmeter/factory/group/group_2.jmx
+++ b/src/test/resources/net/simonix/dsl/jmeter/factory/group/group_2.jmx
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ Copyright 2022 Szymon Micyk
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.4.3">
+  <hashTree>
+    <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="Test Plan" enabled="true">
+      <stringProp name="TestPlan.comments"></stringProp>
+      <boolProp name="TestPlan.serialize_threadgroups">false</boolProp>
+      <boolProp name="TestPlan.functional_mode">false</boolProp>
+      <boolProp name="TestPlan.tearDown_on_shutdown">true</boolProp>
+      <stringProp name="TestPlan.user_define_classpath"></stringProp>
+      <elementProp name="TestPlan.user_defined_variables" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" enabled="true">
+        <collectionProp name="Arguments.arguments"/>
+      </elementProp>
+    </TestPlan>
+    <hashTree>
+      <Arguments guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
+        <collectionProp name="Arguments.arguments">
+          <elementProp name="var_users" elementType="Argument">
+            <stringProp name="Argument.name">var_users</stringProp>
+            <stringProp name="Argument.value">10</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="var_rampUp" elementType="Argument">
+            <stringProp name="Argument.name">var_rampUp</stringProp>
+            <stringProp name="Argument.value">60</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="var_delay" elementType="Argument">
+            <stringProp name="Argument.name">var_delay</stringProp>
+            <stringProp name="Argument.value">10</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="var_delayedStart" elementType="Argument">
+            <stringProp name="Argument.name">var_delayedStart</stringProp>
+            <stringProp name="Argument.value">10</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="var_duration" elementType="Argument">
+            <stringProp name="Argument.name">var_duration</stringProp>
+            <stringProp name="Argument.value">10</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="var_loops" elementType="Argument">
+            <stringProp name="Argument.name">var_loops</stringProp>
+            <stringProp name="Argument.value">2</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="var_onError" elementType="Argument">
+            <stringProp name="Argument.name">var_onError</stringProp>
+            <stringProp name="Argument.value">stop_test</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+        </collectionProp>
+      </Arguments>
+      <hashTree/>
+      <SetupThreadGroup guiclass="SetupThreadGroupGui" testclass="SetupThreadGroup" testname="setUp User Group" enabled="true">
+        <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+        <stringProp name="ThreadGroup.num_threads">${var_users}</stringProp>
+        <stringProp name="ThreadGroup.ramp_time">${var_rampUp}</stringProp>
+        <boolProp name="ThreadGroup.same_user_on_next_iteration">false</boolProp>
+        <boolProp name="ThreadGroup.scheduler">true</boolProp>
+        <stringProp name="ThreadGroup.duration">${var_delay}</stringProp>
+        <stringProp name="ThreadGroup.delay">${var_duration}</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" enabled="true">
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+          <stringProp name="LoopController.loops">${var_loops}</stringProp>
+        </elementProp>
+      </SetupThreadGroup>
+      <hashTree/>
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="User Group" enabled="true">
+        <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+        <stringProp name="ThreadGroup.num_threads">${var_users}</stringProp>
+        <stringProp name="ThreadGroup.ramp_time">${var_delay}</stringProp>
+        <boolProp name="ThreadGroup.delayedStart">true</boolProp>
+        <boolProp name="ThreadGroup.same_user_on_next_iteration">false</boolProp>
+        <boolProp name="ThreadGroup.scheduler">true</boolProp>
+        <stringProp name="ThreadGroup.duration">${var_delay}</stringProp>
+        <stringProp name="ThreadGroup.delay">${var_duration}</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" enabled="true">
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+          <stringProp name="LoopController.loops">${var_loops}</stringProp>
+        </elementProp>
+      </ThreadGroup>
+      <hashTree/>
+      <PostThreadGroup guiclass="PostThreadGroupGui" testclass="PostThreadGroup" testname="tearDown User Group" enabled="true">
+        <stringProp name="ThreadGroup.on_sample_error">stoptest</stringProp>
+        <stringProp name="ThreadGroup.num_threads">${var_users}</stringProp>
+        <stringProp name="ThreadGroup.ramp_time">${var_duration}</stringProp>
+        <boolProp name="ThreadGroup.same_user_on_next_iteration">false</boolProp>
+        <boolProp name="ThreadGroup.scheduler">true</boolProp>
+        <stringProp name="ThreadGroup.duration">${var_delay}</stringProp>
+        <stringProp name="ThreadGroup.delay">${var_duration}</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" enabled="true">
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+          <stringProp name="LoopController.loops">${var_loops}</stringProp>
+        </elementProp>
+      </PostThreadGroup>
+      <hashTree/>
+    </hashTree>
+  </hashTree>
+</jmeterTestPlan>

--- a/src/test/resources/net/simonix/dsl/jmeter/factory/jsr/jsr_0.jmx
+++ b/src/test/resources/net/simonix/dsl/jmeter/factory/jsr/jsr_0.jmx
@@ -36,8 +36,8 @@
         <boolProp name="ThreadGroup.delayedStart">false</boolProp>
         <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
         <boolProp name="ThreadGroup.scheduler">false</boolProp>
-        <longProp name="ThreadGroup.delay">0</longProp>
-        <longProp name="ThreadGroup.duration">0</longProp>
+        <intProp name="ThreadGroup.duration">0</intProp>
+        <intProp name="ThreadGroup.delay">0</intProp>
         <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" enabled="true">
           <boolProp name="LoopController.continue_forever">false</boolProp>
           <intProp name="LoopController.loops">1</intProp>

--- a/src/test/resources/net/simonix/dsl/jmeter/factory/sampler/ajp_0.jmx
+++ b/src/test/resources/net/simonix/dsl/jmeter/factory/sampler/ajp_0.jmx
@@ -79,7 +79,7 @@
         </elementProp>
         <stringProp name="HTTPSampler.protocol">http</stringProp>
         <stringProp name="HTTPSampler.domain">example.com</stringProp>
-        <intProp name="HTTPSampler.port">80</intProp>
+        <stringProp name="HTTPSampler.port">80</stringProp>
         <stringProp name="HTTPSampler.method">GET</stringProp>
         <stringProp name="HTTPSampler.path">/</stringProp>
         <stringProp name="HTTPSampler.contentEncoding">UTF-8</stringProp>

--- a/src/test/resources/net/simonix/dsl/jmeter/factory/sampler/graphql_0.jmx
+++ b/src/test/resources/net/simonix/dsl/jmeter/factory/sampler/graphql_0.jmx
@@ -36,8 +36,8 @@
         <boolProp name="ThreadGroup.delayedStart">false</boolProp>
         <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
         <boolProp name="ThreadGroup.scheduler">false</boolProp>
-        <longProp name="ThreadGroup.delay">0</longProp>
-        <longProp name="ThreadGroup.duration">0</longProp>
+        <intProp name="ThreadGroup.duration">0</intProp>
+        <intProp name="ThreadGroup.delay">0</intProp>
         <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" enabled="true">
           <boolProp name="LoopController.continue_forever">false</boolProp>
           <intProp name="LoopController.loops">1</intProp>
@@ -116,7 +116,7 @@
           </elementProp>
           <stringProp name="HTTPSampler.protocol">http</stringProp>
           <stringProp name="HTTPSampler.domain">example.com</stringProp>
-          <intProp name="HTTPSampler.port">80</intProp>
+          <stringProp name="HTTPSampler.port">80</stringProp>
           <stringProp name="HTTPSampler.method">GET</stringProp>
           <stringProp name="HTTPSampler.path">/graphql</stringProp>
           <stringProp name="HTTPSampler.contentEncoding">UTF-8</stringProp>

--- a/src/test/resources/net/simonix/dsl/jmeter/factory/sampler/http_0.jmx
+++ b/src/test/resources/net/simonix/dsl/jmeter/factory/sampler/http_0.jmx
@@ -79,7 +79,7 @@
         </elementProp>
         <stringProp name="HTTPSampler.protocol">http</stringProp>
         <stringProp name="HTTPSampler.domain">example.com</stringProp>
-        <intProp name="HTTPSampler.port">80</intProp>
+        <stringProp name="HTTPSampler.port">80</stringProp>
         <stringProp name="HTTPSampler.method">GET</stringProp>
         <stringProp name="HTTPSampler.path">/</stringProp>
         <stringProp name="HTTPSampler.contentEncoding">UTF-8</stringProp>

--- a/src/test/resources/net/simonix/dsl/jmeter/factory/timer/timers_0.jmx
+++ b/src/test/resources/net/simonix/dsl/jmeter/factory/timer/timers_0.jmx
@@ -62,35 +62,23 @@
       <hashTree/>
       <ConstantThroughputTimer guiclass="TestBeanGUI" testclass="ConstantThroughputTimer" testname="Constant Throughput Timer" enabled="true">
         <intProp name="calcMode">0</intProp>
-        <doubleProp>
-          <name>throughput</name>
-          <value>0.0</value>
-          <savedValue>0.0</savedValue>
-        </doubleProp>
+        <stringProp name="throughput">0.0</stringProp>
       </ConstantThroughputTimer>
       <hashTree/>
       <PreciseThroughputTimer guiclass="TestBeanGUI" testclass="PreciseThroughputTimer" testname="Precise Throughput Timer" enabled="true">
-        <doubleProp>
-          <name>throughput</name>
-          <value>100.0</value>
-          <savedValue>0.0</savedValue>
-        </doubleProp>
+        <stringProp name="throughput">100.0</stringProp>
         <intProp name="throughputPeriod">3600</intProp>
-        <longProp name="duration">3600</longProp>
+        <intProp name="duration">3600</intProp>
         <intProp name="batchSize">1</intProp>
         <intProp name="batchThreadDelay">0</intProp>
         <intProp name="exactLimit">10000</intProp>
-        <doubleProp>
-          <name>allowedThroughputSurplus</name>
-          <value>1.0</value>
-          <savedValue>0.0</savedValue>
-        </doubleProp>
-        <longProp name="randomSeed">0</longProp>
+        <stringProp name="allowedThroughputSurplus">0</stringProp>
+        <intProp name="randomSeed">0</intProp>
       </PreciseThroughputTimer>
       <hashTree/>
       <SyncTimer guiclass="TestBeanGUI" testclass="SyncTimer" testname="Synchronizing Timer" enabled="true">
         <intProp name="groupSize">0</intProp>
-        <longProp name="timeoutInMs">0</longProp>
+        <intProp name="timeoutInMs">0</intProp>
       </SyncTimer>
       <hashTree/>
     </hashTree>

--- a/src/test/resources/net/simonix/dsl/jmeter/factory/timer/timers_1.jmx
+++ b/src/test/resources/net/simonix/dsl/jmeter/factory/timer/timers_1.jmx
@@ -62,35 +62,23 @@
       <hashTree/>
       <ConstantThroughputTimer guiclass="TestBeanGUI" testclass="ConstantThroughputTimer" testname="Constant Throughput Timer" enabled="true">
         <intProp name="calcMode">1</intProp>
-        <doubleProp>
-          <name>throughput</name>
-          <value>200.0</value>
-          <savedValue>0.0</savedValue>
-        </doubleProp>
+        <stringProp name="throughput">200</stringProp>
       </ConstantThroughputTimer>
       <hashTree/>
       <PreciseThroughputTimer guiclass="TestBeanGUI" testclass="PreciseThroughputTimer" testname="Precise Throughput Timer" enabled="true">
-        <doubleProp>
-          <name>throughput</name>
-          <value>200.0</value>
-          <savedValue>0.0</savedValue>
-        </doubleProp>
+        <stringProp name="throughput">200</stringProp>
         <intProp name="throughputPeriod">1000</intProp>
-        <longProp name="duration">1000</longProp>
+        <intProp name="duration">1000</intProp>
         <intProp name="batchSize">10</intProp>
         <intProp name="batchThreadDelay">10</intProp>
         <intProp name="exactLimit">1000</intProp>
-        <doubleProp>
-          <name>allowedThroughputSurplus</name>
-          <value>50.0</value>
-          <savedValue>0.0</savedValue>
-        </doubleProp>
-        <longProp name="randomSeed">100000</longProp>
+        <stringProp name="allowedThroughputSurplus">10</stringProp>
+        <intProp name="randomSeed">100000</intProp>
       </PreciseThroughputTimer>
       <hashTree/>
       <SyncTimer guiclass="TestBeanGUI" testclass="SyncTimer" testname="Synchronizing Timer" enabled="true">
         <intProp name="groupSize">100</intProp>
-        <longProp name="timeoutInMs">1000</longProp>
+        <intProp name="timeoutInMs">1000</intProp>
       </SyncTimer>
       <hashTree/>
     </hashTree>

--- a/src/test/resources/net/simonix/dsl/jmeter/factory/timer/timers_2.jmx
+++ b/src/test/resources/net/simonix/dsl/jmeter/factory/timer/timers_2.jmx
@@ -62,35 +62,23 @@
       <hashTree/>
       <ConstantThroughputTimer guiclass="TestBeanGUI" testclass="ConstantThroughputTimer" testname="Constant Throughput Timer" enabled="true">
         <intProp name="calcMode">0</intProp>
-        <doubleProp>
-          <name>throughput</name>
-          <value>0.0</value>
-          <savedValue>0.0</savedValue>
-        </doubleProp>
+        <stringProp name="throughput">0.0</stringProp>
       </ConstantThroughputTimer>
       <hashTree/>
       <PreciseThroughputTimer guiclass="TestBeanGUI" testclass="PreciseThroughputTimer" testname="Precise Throughput Timer" enabled="true">
-        <doubleProp>
-          <name>throughput</name>
-          <value>100.0</value>
-          <savedValue>0.0</savedValue>
-        </doubleProp>
+        <stringProp name="throughput">100.0</stringProp>
         <intProp name="throughputPeriod">3600</intProp>
-        <longProp name="duration">3600</longProp>
+        <intProp name="duration">3600</intProp>
         <intProp name="batchSize">1</intProp>
         <intProp name="batchThreadDelay">0</intProp>
         <intProp name="exactLimit">10000</intProp>
-        <doubleProp>
-          <name>allowedThroughputSurplus</name>
-          <value>1.0</value>
-          <savedValue>0.0</savedValue>
-        </doubleProp>
-        <longProp name="randomSeed">0</longProp>
+        <stringProp name="allowedThroughputSurplus">0</stringProp>
+        <intProp name="randomSeed">0</intProp>
       </PreciseThroughputTimer>
       <hashTree/>
       <SyncTimer guiclass="TestBeanGUI" testclass="SyncTimer" testname="Synchronizing Timer" enabled="true">
         <intProp name="groupSize">0</intProp>
-        <longProp name="timeoutInMs">0</longProp>
+        <intProp name="timeoutInMs">0</intProp>
       </SyncTimer>
       <hashTree/>
     </hashTree>

--- a/src/test/resources/net/simonix/dsl/jmeter/factory/timer/timers_3.jmx
+++ b/src/test/resources/net/simonix/dsl/jmeter/factory/timer/timers_3.jmx
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ Copyright 2022 Szymon Micyk
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.4.3">
+  <hashTree>
+    <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="Test Plan" enabled="true">
+      <stringProp name="TestPlan.comments"></stringProp>
+      <boolProp name="TestPlan.serialize_threadgroups">false</boolProp>
+      <boolProp name="TestPlan.functional_mode">false</boolProp>
+      <boolProp name="TestPlan.tearDown_on_shutdown">true</boolProp>
+      <stringProp name="TestPlan.user_define_classpath"></stringProp>
+      <elementProp name="TestPlan.user_defined_variables" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" enabled="true">
+        <collectionProp name="Arguments.arguments"/>
+      </elementProp>
+    </TestPlan>
+    <hashTree>
+      <Arguments guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
+        <collectionProp name="Arguments.arguments">
+          <elementProp name="var_delay" elementType="Argument">
+            <stringProp name="Argument.name">var_delay</stringProp>
+            <stringProp name="Argument.value">500</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="var_range" elementType="Argument">
+            <stringProp name="Argument.name">var_range</stringProp>
+            <stringProp name="Argument.value">1000</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="var_target" elementType="Argument">
+            <stringProp name="Argument.name">var_target</stringProp>
+            <stringProp name="Argument.value">200</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="var_basedOn" elementType="Argument">
+            <stringProp name="Argument.name">var_basedOn</stringProp>
+            <stringProp name="Argument.value">all_users</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="var_period" elementType="Argument">
+            <stringProp name="Argument.name">var_period</stringProp>
+            <stringProp name="Argument.value">1000</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="var_duration" elementType="Argument">
+            <stringProp name="Argument.name">var_duration</stringProp>
+            <stringProp name="Argument.value">1000</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="var_batchUsers" elementType="Argument">
+            <stringProp name="Argument.name">var_batchUsers</stringProp>
+            <stringProp name="Argument.value">10</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="var_batchDelay" elementType="Argument">
+            <stringProp name="Argument.name">var_batchDelay</stringProp>
+            <stringProp name="Argument.value">10</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="var_samples" elementType="Argument">
+            <stringProp name="Argument.name">var_samples</stringProp>
+            <stringProp name="Argument.value">1000</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="var_percent" elementType="Argument">
+            <stringProp name="Argument.name">var_percent</stringProp>
+            <stringProp name="Argument.value">50</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="var_seed" elementType="Argument">
+            <stringProp name="Argument.name">var_seed</stringProp>
+            <stringProp name="Argument.value">100000</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="var_users" elementType="Argument">
+            <stringProp name="Argument.name">var_users</stringProp>
+            <stringProp name="Argument.value">100</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="var_timeout" elementType="Argument">
+            <stringProp name="Argument.name">var_timeout</stringProp>
+            <stringProp name="Argument.value">1000</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+        </collectionProp>
+      </Arguments>
+      <hashTree/>
+      <ConstantTimer guiclass="ConstantTimerGui" testclass="ConstantTimer" testname="Constant Timer" enabled="true">
+        <stringProp name="ConstantTimer.delay">${var_delay}</stringProp>
+      </ConstantTimer>
+      <hashTree/>
+      <UniformRandomTimer guiclass="UniformRandomTimerGui" testclass="UniformRandomTimer" testname="Uniform Random Timer" enabled="true">
+        <stringProp name="ConstantTimer.delay">${var_delay}</stringProp>
+        <stringProp name="RandomTimer.range">${var_range}</stringProp>
+      </UniformRandomTimer>
+      <hashTree/>
+      <PoissonRandomTimer guiclass="PoissonRandomTimerGui" testclass="PoissonRandomTimer" testname="Poisson Random Timer" enabled="true">
+        <stringProp name="ConstantTimer.delay">${var_delay}</stringProp>
+        <stringProp name="RandomTimer.range">${var_range}</stringProp>
+      </PoissonRandomTimer>
+      <hashTree/>
+      <GaussianRandomTimer guiclass="GaussianRandomTimerGui" testclass="GaussianRandomTimer" testname="Gaussian Random Timer" enabled="true">
+        <stringProp name="ConstantTimer.delay">${var_delay}</stringProp>
+        <stringProp name="RandomTimer.range">${var_range}</stringProp>
+      </GaussianRandomTimer>
+      <hashTree/>
+      <ConstantThroughputTimer guiclass="TestBeanGUI" testclass="ConstantThroughputTimer" testname="Constant Throughput Timer" enabled="true">
+        <intProp name="calcMode">0</intProp>
+        <stringProp name="throughput">${var_target}</stringProp>
+      </ConstantThroughputTimer>
+      <hashTree/>
+      <PreciseThroughputTimer guiclass="TestBeanGUI" testclass="PreciseThroughputTimer" testname="Precise Throughput Timer" enabled="true">
+        <stringProp name="throughput">${var_target}</stringProp>
+        <stringProp name="throughputPeriod">${var_period}</stringProp>
+        <stringProp name="duration">${var_duration}</stringProp>
+        <stringProp name="batchSize">${var_batchUsers}</stringProp>
+        <stringProp name="batchThreadDelay">${var_batchDelay}</stringProp>
+        <stringProp name="exactLimit">${var_samples}</stringProp>
+        <stringProp name="allowedThroughputSurplus">${var_batchDelay}</stringProp>
+        <stringProp name="randomSeed">${var_seed}</stringProp>
+      </PreciseThroughputTimer>
+      <hashTree/>
+      <SyncTimer guiclass="TestBeanGUI" testclass="SyncTimer" testname="Synchronizing Timer" enabled="true">
+        <stringProp name="groupSize">${var_users}</stringProp>
+        <stringProp name="timeoutInMs">${var_timeout}</stringProp>
+      </SyncTimer>
+      <hashTree/>
+    </hashTree>
+  </hashTree>
+</jmeterTestPlan>


### PR DESCRIPTION
… test elements

- the command line parameters J and G added, will work the same as for jmeter command line
- the jmeter expression can be used in numerical fields for several keywords
- update container versions for grafana, influxdb and telegraf
- update examples to show usage J and G command line parameters