### PR TITLE
[feature] - changes in check handlers

### DIFF
--- a/src/main/groovy/net/simonix/dsl/jmeter/factory/assertion/CheckFactory.groovy
+++ b/src/main/groovy/net/simonix/dsl/jmeter/factory/assertion/CheckFactory.groovy
@@ -134,7 +134,9 @@ abstract class CheckFactory extends AbstractFactory implements ValidatorProvider
     Object newInstance(FactoryBuilderSupport builder, Object name, Object value, Map config) throws InstantiationException, IllegalAccessException {
         String applyTo = readValue(value, config.applyTo)
 
-        return new CheckTestElementNode(applyTo)
+        boolean enabled = readValue(config.enabled, true)
+
+        return new CheckTestElementNode(enabled, applyTo)
     }
 
     boolean onHandleNodeAttributes(FactoryBuilderSupport builder, Object node, Map config) {

--- a/src/main/groovy/net/simonix/dsl/jmeter/handler/CheckRequestHandler.groovy
+++ b/src/main/groovy/net/simonix/dsl/jmeter/handler/CheckRequestHandler.groovy
@@ -19,10 +19,10 @@ import groovy.transform.CompileDynamic
 import net.simonix.dsl.jmeter.model.CheckTestElementNode
 import net.simonix.dsl.jmeter.model.TestElementNode
 
+import static net.simonix.dsl.jmeter.utils.ConfigUtils.readValue
+
 @CompileDynamic
 final class CheckRequestHandler implements CheckHandler {
-
-    final static boolean not = true
 
     CheckTestElementNode testElementContainer
     TestElementNode testElementCurrent
@@ -34,26 +34,41 @@ final class CheckRequestHandler implements CheckHandler {
         this.builderSupport = builderSupport
     }
 
-    ResponseHandler headers(boolean negate = false) {
-        String applyTo = testElementContainer.applyTo
-
-        return responseBuildImpl('assert_response', 'Check Headers', applyTo, 'request_headers', negate)
+    ResponseHandler headers(String value) {
+        return headers([:], value)
     }
 
-    ResponseHandler text(boolean negate = false) {
+    ResponseHandler headers(Map config = [:], String value = '') {
         String applyTo = testElementContainer.applyTo
+        String name = readValue(config.name, readValue(value, 'Check Headers'))
+        String comment = readValue(config.comments, '')
+        boolean enabled = readValue(config.enabled, testElementContainer.enabled)
 
-        return responseBuildImpl('assert_response', 'Check Text', applyTo, 'request_data', negate)
+        return responseBuildImpl('assert_response', name, comment, enabled, applyTo, 'request_headers')
     }
 
-    private ResponseHandler responseBuildImpl(String type, String name, String applyTo, String field, boolean negate) {
+    ResponseHandler text(String value) {
+        return text([:], value)
+    }
+
+    ResponseHandler text(Map config = [:], String value = '') {
+        String applyTo = testElementContainer.applyTo
+        String name = readValue(config.name, readValue(value, 'Check Text'))
+        String comment = readValue(config.comments, '')
+        boolean enabled = readValue(config.enabled, testElementContainer.enabled)
+
+        return responseBuildImpl('assert_response', name, comment, enabled, applyTo, 'request_data')
+    }
+
+    private ResponseHandler responseBuildImpl(String type, String name, String comment, boolean enabled, String applyTo, String field) {
         Factory factory = builderSupport.factories.get(type)
 
         Map config = [:]
         config.name = name
+        config.comment = comment
+        config.enabled = enabled
         config.applyTo = applyTo
         config.field = field
-        config.negate = negate
 
         testElementCurrent = factory.newInstance(builderSupport, type, null, config) as TestElementNode
         testElementContainer.add(testElementCurrent)

--- a/src/main/groovy/net/simonix/dsl/jmeter/handler/CheckResponseHandler.groovy
+++ b/src/main/groovy/net/simonix/dsl/jmeter/handler/CheckResponseHandler.groovy
@@ -19,10 +19,10 @@ import groovy.transform.CompileDynamic
 import net.simonix.dsl.jmeter.model.CheckTestElementNode
 import net.simonix.dsl.jmeter.model.TestElementNode
 
+import static net.simonix.dsl.jmeter.utils.ConfigUtils.readValue
+
 @CompileDynamic
 final class CheckResponseHandler implements CheckHandler {
-
-    final static boolean not = true
 
     CheckTestElementNode testElementContainer
     TestElementNode testElementCurrent
@@ -34,62 +34,119 @@ final class CheckResponseHandler implements CheckHandler {
         this.builderSupport = builderSupport
     }
 
-    ResponseHandler status(boolean negate = false) {
-        String applyTo = testElementContainer.applyTo
-
-        return responseBuildImpl('assert_response', 'Check Status', applyTo, 'response_code', negate)
+    ResponseHandler status(String value) {
+        return status([:], value)
     }
 
-    ResponseHandler headers(boolean negate = false) {
+    ResponseHandler status(Map config = [:], String value = '') {
         String applyTo = testElementContainer.applyTo
+        String name = readValue(config.name, readValue(value, 'Check Status'))
+        String comment = readValue(config.comments, '')
+        boolean enabled = readValue(config.enabled, testElementContainer.enabled)
 
-        return responseBuildImpl('assert_response', 'Check Headers', applyTo, 'response_headers', negate)
+        return responseBuildImpl('assert_response', name, comment, enabled, applyTo, 'response_code')
     }
 
-    ResponseHandler text(boolean negate = false) {
-        String applyTo = testElementContainer.applyTo
-
-        return responseBuildImpl('assert_response', 'Check Text', applyTo, 'response_text', negate)
+    ResponseHandler headers(String value) {
+        return headers([:], value)
     }
 
-    ResponseHandler document(boolean negate = false) {
+    ResponseHandler headers(Map config = [:], String value = '') {
         String applyTo = testElementContainer.applyTo
+        String name = readValue(config.name, readValue(value, 'Check Headers'))
+        String comment = readValue(config.comments, '')
+        boolean enabled = readValue(config.enabled, testElementContainer.enabled)
 
-        return responseBuildImpl('assert_response', 'Check Document', applyTo, 'response_document', negate)
+        return responseBuildImpl('assert_response', name, comment, enabled, applyTo, 'response_headers')
     }
 
-    ResponseHandler message(boolean negate = false) {
-        String applyTo = testElementContainer.applyTo
-
-        return responseBuildImpl('assert_response', 'Check Message', applyTo, 'response_message', negate)
+    ResponseHandler text(String value) {
+        return text([:], value)
     }
 
-    ResponseHandler url(boolean negate = false) {
+    ResponseHandler text(Map config = [:], String value = '') {
         String applyTo = testElementContainer.applyTo
+        String name = readValue(config.name, readValue(value, 'Check Text'))
+        String comment = readValue(config.comments, '')
+        boolean enabled = readValue(config.enabled, testElementContainer.enabled)
 
-        return responseBuildImpl('assert_response', 'Check Url', applyTo, 'response_url', negate)
+        return responseBuildImpl('assert_response', name, comment, enabled, applyTo, 'response_text')
     }
 
-    DurationHandler duration() {
-        String applyTo = testElementContainer.applyTo
-
-        return durationBuildImpl('assert_duration', 'Check duration', applyTo)
+    ResponseHandler document(String value) {
+        return document([:], value)
     }
 
-    MD5HexHandler md5hex() {
+    ResponseHandler document(Map config = [:], String value = '') {
         String applyTo = testElementContainer.applyTo
+        String name = readValue(config.name, readValue(value, 'Check Document'))
+        String comment = readValue(config.comments, '')
+        boolean enabled = readValue(config.enabled, testElementContainer.enabled)
 
-        return md5hexBuildImpl('assert_md5hex', 'Check MD5Hex', applyTo)
+        return responseBuildImpl('assert_response', name, comment, enabled, applyTo, 'response_document')
     }
 
-    private ResponseHandler responseBuildImpl(String type, String name, String applyTo, String field, boolean negate) {
+    ResponseHandler message(String value) {
+        return message([:], value)
+    }
+
+    ResponseHandler message(Map config = [:], String value = '') {
+        String applyTo = testElementContainer.applyTo
+        String name = readValue(config.name, readValue(value, 'Check Message'))
+        String comment = readValue(config.comments, '')
+        boolean enabled = readValue(config.enabled, testElementContainer.enabled)
+
+        return responseBuildImpl('assert_response', name, comment, enabled, applyTo, 'response_message')
+    }
+
+    ResponseHandler url(String value) {
+        return url([:], value)
+    }
+
+    ResponseHandler url(Map config = [:], String value = '') {
+        String applyTo = testElementContainer.applyTo
+        String name = readValue(config.name, readValue(value, 'Check Url'))
+        String comment = readValue(config.comments, '')
+        boolean enabled = readValue(config.enabled, testElementContainer.enabled)
+
+        return responseBuildImpl('assert_response', name, comment, enabled, applyTo, 'response_url')
+    }
+
+    DurationHandler duration(String value) {
+        return duration([:], value)
+    }
+
+    DurationHandler duration(Map config = [:], String value = '') {
+        String applyTo = testElementContainer.applyTo
+        String name = readValue(config.name, readValue(value, 'Check Duration'))
+        String comment = readValue(config.comments, '')
+        boolean enabled = readValue(config.enabled, testElementContainer.enabled)
+
+        return durationBuildImpl('assert_duration', name, comment, enabled, applyTo)
+    }
+
+    MD5HexHandler md5hex(String value) {
+        return md5hex([:], value)
+    }
+
+    MD5HexHandler md5hex(Map config = [:], String value = '') {
+        String applyTo = testElementContainer.applyTo
+        String name = readValue(config.name, readValue(value, 'Check MD5Hex'))
+        String comment = readValue(config.comments, '')
+        boolean enabled = readValue(config.enabled, testElementContainer.enabled)
+
+        return md5hexBuildImpl('assert_md5hex', name, comment, enabled, applyTo)
+    }
+
+    private ResponseHandler responseBuildImpl(String type, String name, String comment, boolean enabled, String applyTo, String field) {
         Factory factory = builderSupport.getFactories().get(type)
 
         Map config = [:]
         config.name = name
+        config.comment = comment
+        config.enabled = enabled
         config.applyTo = applyTo
         config.field = field
-        config.negate = negate
 
         testElementCurrent = factory.newInstance(builderSupport, type, null, config) as TestElementNode
         testElementContainer.add(testElementCurrent)
@@ -97,11 +154,13 @@ final class CheckResponseHandler implements CheckHandler {
         return new ResponseHandler(testElementCurrent)
     }
 
-    private DurationHandler durationBuildImpl(String type, String name, String applyTo) {
+    private DurationHandler durationBuildImpl(String type, String name, String comment, boolean enabled, String applyTo) {
         Factory factory = builderSupport.getFactories().get(type)
 
         Map config = [:]
         config.name = name
+        config.comment = comment
+        config.enabled = enabled
         config.applyTo = applyTo
 
         testElementCurrent = factory.newInstance(builderSupport, type, null, config) as TestElementNode
@@ -110,11 +169,13 @@ final class CheckResponseHandler implements CheckHandler {
         return new DurationHandler(testElementCurrent)
     }
 
-    private MD5HexHandler md5hexBuildImpl(String type, String name, String applyTo) {
+    private MD5HexHandler md5hexBuildImpl(String type, String name, String comment, boolean enabled, String applyTo) {
         Factory factory = builderSupport.getFactories().get(type)
 
         Map config = [:]
         config.name = name
+        config.comment = comment
+        config.enabled = enabled
         config.applyTo = applyTo
 
         testElementCurrent = factory.newInstance(builderSupport, type, null, config) as TestElementNode

--- a/src/main/groovy/net/simonix/dsl/jmeter/handler/CheckSizeHandler.groovy
+++ b/src/main/groovy/net/simonix/dsl/jmeter/handler/CheckSizeHandler.groovy
@@ -19,10 +19,10 @@ import groovy.transform.CompileDynamic
 import net.simonix.dsl.jmeter.model.CheckTestElementNode
 import net.simonix.dsl.jmeter.model.TestElementNode
 
+import static net.simonix.dsl.jmeter.utils.ConfigUtils.readValue
+
 @CompileDynamic
 final class CheckSizeHandler implements CheckHandler {
-
-    final static boolean not = true
 
     CheckTestElementNode testElementContainer
     TestElementNode testElementCurrent
@@ -34,41 +34,78 @@ final class CheckSizeHandler implements CheckHandler {
         this.builderSupport = builderSupport
     }
 
-    SizeHandler status() {
-        String applyTo = testElementContainer.applyTo
-
-        return sizeBuildImpl('assert_size', 'Check Size', applyTo, 'response_status')
+    SizeHandler status(String value) {
+        return status([:], value)
     }
 
-    SizeHandler headers() {
+    SizeHandler status(Map config = [:], String value = '') {
         String applyTo = testElementContainer.applyTo
+        String name = readValue(config.name, readValue(value, 'Check Size'))
+        String comment = readValue(config.comments, '')
+        boolean enabled = readValue(config.enabled, testElementContainer.enabled)
 
-        return sizeBuildImpl('assert_size', 'Check Size', applyTo, 'response_headers')
+        return sizeBuildImpl('assert_size', name, comment, enabled, applyTo, 'response_status')
     }
 
-    SizeHandler text() {
-        String applyTo = testElementContainer.applyTo
-
-        return sizeBuildImpl('assert_size', 'Check Size', applyTo, 'response_data')
+    SizeHandler headers(String value) {
+        return headers([:], value)
     }
 
-    SizeHandler body() {
+    SizeHandler headers(Map config = [:], String value = '') {
         String applyTo = testElementContainer.applyTo
+        String name = readValue(config.name, readValue(value, 'Check Size'))
+        String comment = readValue(config.comments, '')
+        boolean enabled = readValue(config.enabled, testElementContainer.enabled)
 
-        return sizeBuildImpl('assert_size', 'Check Size', applyTo, 'response_body')
+        return sizeBuildImpl('assert_size', name, comment, enabled, applyTo, 'response_headers')
     }
 
-    SizeHandler message() {
-        String applyTo = testElementContainer.applyTo
-
-        return sizeBuildImpl('assert_size', 'Check Size', applyTo, 'response_message')
+    SizeHandler text(String value) {
+        return text([:], value)
     }
 
-    private SizeHandler sizeBuildImpl(String type, String name, String applyTo, String field) {
+    SizeHandler text(Map config = [:], String value = '') {
+        String applyTo = testElementContainer.applyTo
+        String name = readValue(config.name, readValue(value, 'Check Size'))
+        String comment = readValue(config.comments, '')
+        boolean enabled = readValue(config.enabled, testElementContainer.enabled)
+
+        return sizeBuildImpl('assert_size', name, comment, enabled, applyTo, 'response_data')
+    }
+
+    SizeHandler body(String value) {
+        return body([:], value)
+    }
+
+    SizeHandler body(Map config = [:], String value = '') {
+        String applyTo = testElementContainer.applyTo
+        String name = readValue(config.name, readValue(value, 'Check Size'))
+        String comment = readValue(config.comments, '')
+        boolean enabled = readValue(config.enabled, testElementContainer.enabled)
+
+        return sizeBuildImpl('assert_size', name, comment, enabled, applyTo, 'response_body')
+    }
+
+    SizeHandler message(String value) {
+        return message([:], value)
+    }
+
+    SizeHandler message(Map config = [:], String value = '') {
+        String applyTo = testElementContainer.applyTo
+        String name = readValue(config.name, readValue(value, 'Check Size'))
+        String comment = readValue(config.comments, '')
+        boolean enabled = readValue(config.enabled, testElementContainer.enabled)
+
+        return sizeBuildImpl('assert_size', name, comment, enabled, applyTo, 'response_message')
+    }
+
+    private SizeHandler sizeBuildImpl(String type, String name, String comment, boolean enabled, String applyTo, String field) {
         Factory factory = builderSupport.getFactories().get(type)
 
         Map config = [:]
         config.name = name
+        config.comment = comment
+        config.enabled = enabled
         config.applyTo = applyTo
         config.field = field
         config.rule = 'ne'

--- a/src/main/groovy/net/simonix/dsl/jmeter/handler/ResponseHandler.groovy
+++ b/src/main/groovy/net/simonix/dsl/jmeter/handler/ResponseHandler.groovy
@@ -27,9 +27,30 @@ final class ResponseHandler {
         this.testElementCurrent = testElementCurrent
     }
 
+    ResponseHandler ne(int value, String message = '') {
+        testElementCurrent.testElement.addTestString(value.toString())
+        testElementCurrent.testElement.setToEqualsType()
+        testElementCurrent.testElement.setToNotType()
+
+        testElementCurrent.testElement.setCustomFailureMessage(message)
+
+        return this
+    }
+
+    ResponseHandler ne(String value, String message = '') {
+        testElementCurrent.testElement.addTestString(value)
+        testElementCurrent.testElement.setToEqualsType()
+        testElementCurrent.testElement.setToNotType()
+
+        testElementCurrent.testElement.setCustomFailureMessage(message)
+
+        return this
+    }
+
     ResponseHandler eq(int value, String message = '') {
         testElementCurrent.testElement.addTestString(value.toString())
         testElementCurrent.testElement.setToEqualsType()
+        testElementCurrent.testElement.unsetNotType()
 
         testElementCurrent.testElement.setCustomFailureMessage(message)
 
@@ -39,6 +60,7 @@ final class ResponseHandler {
     ResponseHandler eq(String value, String message = '') {
         testElementCurrent.testElement.addTestString(value)
         testElementCurrent.testElement.setToEqualsType()
+        testElementCurrent.testElement.unsetNotType()
 
         testElementCurrent.testElement.setCustomFailureMessage(message)
 
@@ -54,9 +76,20 @@ final class ResponseHandler {
         return this
     }
 
-    ResponseHandler contains(String value, String message = '') {
+    ResponseHandler includes(String value, String message = '') {
         testElementCurrent.testElement.addTestString(value)
         testElementCurrent.testElement.setToContainsType()
+        testElementCurrent.testElement.unsetNotType()
+
+        testElementCurrent.testElement.setCustomFailureMessage(message)
+
+        return this
+    }
+
+    ResponseHandler excludes(String value, String message = '') {
+        testElementCurrent.testElement.addTestString(value)
+        testElementCurrent.testElement.setToContainsType()
+        testElementCurrent.testElement.setToNotType()
 
         testElementCurrent.testElement.setCustomFailureMessage(message)
 

--- a/src/main/groovy/net/simonix/dsl/jmeter/model/CheckTestElementNode.groovy
+++ b/src/main/groovy/net/simonix/dsl/jmeter/model/CheckTestElementNode.groovy
@@ -18,18 +18,20 @@ package net.simonix.dsl.jmeter.model
 import groovy.transform.CompileStatic
 
 /**
- * Represents node in test tree structure.
+ * Represents check node in test tree structure.
  * <p>
  * It is container for checks.
  */
 @CompileStatic
 class CheckTestElementNode {
 
+    boolean enabled
     String applyTo
 
     List<TestElementNode> testElementNodes = [] as LinkedList<TestElementNode>
 
-    CheckTestElementNode(String applyTo) {
+    CheckTestElementNode(boolean enabled, String applyTo) {
+        this.enabled = enabled
         this.applyTo = applyTo
     }
 

--- a/src/main/groovy/net/simonix/dsl/jmeter/model/definition/DslDefinition.groovy
+++ b/src/main/groovy/net/simonix/dsl/jmeter/model/definition/DslDefinition.groovy
@@ -1034,16 +1034,19 @@ final class DslDefinition {
     }
 
     static final KeywordDefinition CHECK_RESPONSE = keyword('check_response', KeywordCategory.CHECK) {
+        property(name: 'enabled', type: Boolean, required: false, defaultValue: true)
         property(name: 'applyTo', type: String, required: false, defaultValue: 'all', constraints: inList(['all', 'parent', 'children', 'variable']))
         valueIsProperty()
     }
 
     static final KeywordDefinition CHECK_REQUEST = keyword('check_request', KeywordCategory.CHECK) {
+        property(name: 'enabled', type: Boolean, required: false, defaultValue: true)
         property(name: 'applyTo', type: String, required: false, defaultValue: 'all', constraints: inList(['all', 'parent', 'children', 'variable']))
         valueIsProperty()
     }
 
     static final KeywordDefinition CHECK_SIZE = keyword('check_size', KeywordCategory.CHECK) {
+        property(name: 'enabled', type: Boolean, required: false, defaultValue: true)
         property(name: 'applyTo', type: String, required: false, defaultValue: 'all', constraints: inList(['all', 'parent', 'children', 'variable']))
         valueIsProperty()
     }

--- a/src/test/groovy/net/simonix/dsl/jmeter/factory/assertion/AssertionFactorySpec.groovy
+++ b/src/test/groovy/net/simonix/dsl/jmeter/factory/assertion/AssertionFactorySpec.groovy
@@ -46,9 +46,9 @@ class AssertionFactorySpec extends TempFileSpec {
                     assert_md5hex(name: 'Assert MD5 Factory', comments: 'Factory Comments', value: '--some-value--')
                     assert_md5hex '--some--value--'
 
-                    assert_size(size: 50)
-                    assert_size(name: 'Assert Size Factory', comments: 'Factory Comments', size: 50)
-                    assert_size 50
+                    assert_size(size: 4096)
+                    assert_size(name: 'Assert Size Factory', comments: 'Factory Comments', size: 4096)
+                    assert_size 4096
 
                     assert_xpath()
                     assert_xpath(name: 'Assert XPath Factory', comments: 'Factory Comments', applyTo: 'parent', variable: 'var_variable', expression: '//span', ignoreWhitespace: true, validate: true, useNamespace: true, fetchDtd: true, failOnNoMatch: true, useTolerant: true, reportErrors: true, showWarnings: true, quiet: true)
@@ -65,62 +65,62 @@ class AssertionFactorySpec extends TempFileSpec {
         filesAreTheSame('assertions_0.jmx', resultFile)
     }
 
-    def "Check check generation"() {
+    def "Check assertion DSL generation"() {
         expect: "configure test and save result to the file"
         def config = configure {
             plan {
                 group {
                     check_response {
-                        status(not) eq 200 and 201 and 202, 'is not 2xx'
+                        status() ne 200 and 201 and 202, 'is not 2xx'
                         status() eq 210 and 420 and 530
-                        status(not) eq 201 or 402 or 503
+                        status() ne 201 or 402 or 503
                         status() eq 210 or 420 or 530
 
                         status() substring '500' and '400'
                         status() substring '501' or '401'
 
-                        status() contains 'pattern \\d+' and 'test 123', 'doesn\'t have email'
-                        status() contains 'pattern \\d+' or 'test 123'
+                        status() includes 'pattern \\d+' and 'test 123', 'doesn\'t have email'
+                        status() includes 'pattern \\d+' or 'test 123'
                         status() matches 'pattern \\d+' and 'test 123'
                         status() matches 'pattern \\d+' or 'test 123'
 
-                        headers(not) contains 'COOKIES', 'no cookies'
-                        headers() contains 'COOKIES', 'has cookies'
+                        headers() excludes 'COOKIES', 'no cookies'
+                        headers() includes 'COOKIES', 'has cookies'
 
-                        text(not) contains 'test text'
-                        text() contains 'test text'
+                        text() excludes 'test text'
+                        text() includes 'test text'
 
-                        document(not) contains 'some text'
-                        document() contains 'some text'
+                        document() excludes 'some text'
+                        document() includes 'some text'
 
-                        message(not) eq 'OK', 'Not OK'
+                        message() ne 'OK', 'Not OK'
                         message() eq 'OK', 'OK'
 
-                        url(not) contains 'localhost', 'external'
-                        url() contains 'localhost', 'local'
+                        url() excludes 'localhost', 'external'
+                        url() includes 'localhost', 'local'
 
                         duration() eq 2000
                         md5hex() eq '2bf7b8126bb7c645638e444f6e2c58a5'
                     }
                     check_request {
-                        headers(not) contains 'COOKIES', 'no cookies'
-                        headers() contains 'COOKIES', 'has cookies'
+                        headers() excludes 'COOKIES', 'no cookies'
+                        headers() includes 'COOKIES', 'has cookies'
 
-                        text(not) contains 'test text'
-                        text() contains 'test text'
+                        text() excludes 'test text'
+                        text() includes 'test text'
                     }
                     check_size {
-                        status() eq 200
-                        status() ne 200
-                        status() gt 200
-                        status() lt 200
-                        status() ge 200
-                        status() le 200
+                        status() eq 4096
+                        status() ne 4096
+                        status() gt 4096
+                        status() lt 4096
+                        status() ge 4096
+                        status() le 4096
 
-                        headers() eq 200
-                        text() eq 200
-                        body() eq 200
-                        message() eq 200
+                        headers() eq 4096
+                        text() eq 4096
+                        body() eq 4096
+                        message() eq 4096
                     }
                 }
             }
@@ -133,5 +133,172 @@ class AssertionFactorySpec extends TempFileSpec {
 
         then: 'both files matches'
         filesAreTheSame('assertions_1.jmx', resultFile)
+    }
+
+    def "Check assertion DSL with properties generation"() {
+        expect: "configure test and save result to the file"
+        def config = configure {
+            plan {
+                group {
+                    check_response {
+                        status(name: 'Check Name', comments: 'Check Comments', enabled: false) ne 200 and 201 and 202, 'is not 2xx'
+                        status(name: 'Check Name', comments: 'Check Comments', enabled: false) substring '500' and '400'
+                        status(name: 'Check Name', comments: 'Check Comments', enabled: false) includes 'pattern \\d+' or 'test 123'
+                        status(name: 'Check Name', comments: 'Check Comments', enabled: false) matches 'pattern \\d+' and 'test 123'
+                        status('Check Name', comments: 'Check Comments', enabled: false) matches 'pattern \\d+' and 'test 123'
+                        status('Check Name') matches 'pattern \\d+' and 'test 123'
+
+                        headers(name: 'Check Name', comments: 'Check Comments', enabled: false) includes 'COOKIES', 'has cookies'
+                        headers('Check Name', comments: 'Check Comments', enabled: false) includes 'COOKIES', 'has cookies'
+                        headers('Check Name') includes 'COOKIES', 'has cookies'
+
+                        text(name: 'Check Name', comments: 'Check Comments', enabled: false) includes 'test text'
+                        text('Check Name', comments: 'Check Comments', enabled: false) includes 'test text'
+                        text('Check Name') includes 'test text'
+
+                        document(name: 'Check Name', comments: 'Check Comments', enabled: false) includes 'some text'
+                        document('Check Name', comments: 'Check Comments', enabled: false) includes 'some text'
+                        document('Check Name') includes 'some text'
+
+                        message(name: 'Check Name', comments: 'Check Comments', enabled: false) eq 'OK', 'OK'
+                        message('Check Name', comments: 'Check Comments', enabled: false) eq 'OK', 'OK'
+                        message('Check Name') eq 'OK', 'OK'
+
+                        url(name: 'Check Name', comments: 'Check Comments', enabled: false) includes 'localhost', 'local'
+                        url('Check Name', comments: 'Check Comments', enabled: false) includes 'localhost', 'local'
+                        url('Check Name') includes 'localhost', 'local'
+
+                        duration(name: 'Check Name', comments: 'Check Comments', enabled: false) eq 2000
+                        duration('Check Name', comments: 'Check Comments', enabled: false) eq 2000
+                        duration('Check Name') eq 2000
+
+                        md5hex(name: 'Check Name', comments: 'Check Comments', enabled: false) eq '2bf7b8126bb7c645638e444f6e2c58a5'
+                        md5hex('Check Name', comments: 'Check Comments', enabled: false) eq '2bf7b8126bb7c645638e444f6e2c58a5'
+                        md5hex('Check Name') eq '2bf7b8126bb7c645638e444f6e2c58a5'
+                    }
+                    check_request {
+                        headers(name: 'Check Name', comments: 'Check Comments', enabled: false) includes 'COOKIES', 'has cookies'
+                        headers('Check Name', comments: 'Check Comments', enabled: false) includes 'COOKIES', 'has cookies'
+                        headers('Check Name') includes 'COOKIES', 'has cookies'
+
+                        text(name: 'Check Name', comments: 'Check Comments', enabled: false) includes 'test text'
+                        text('Check Name', comments: 'Check Comments', enabled: false) includes 'test text'
+                        text('Check Name') includes 'test text'
+                    }
+                    check_size {
+                        status(name: 'Check Name', comments: 'Check Comments', enabled: false) eq 4096
+                        status('Check Name', comments: 'Check Comments', enabled: false) eq 4096
+                        status('Check Name') eq 4096
+
+                        headers(name: 'Check Name', comments: 'Check Comments', enabled: false) eq 4096
+                        headers('Check Name', comments: 'Check Comments', enabled: false) eq 4096
+                        headers('Check Name') eq 4096
+
+                        text(name: 'Check Name', comments: 'Check Comments', enabled: false) eq 4096
+                        text('Check Name', comments: 'Check Comments', enabled: false) eq 4096
+                        text('Check Name') eq 4096
+
+                        body(name: 'Check Name', comments: 'Check Comments', enabled: false) eq 4096
+                        body('Check Name', comments: 'Check Comments', enabled: false) eq 4096
+                        body('Check Name') eq 4096
+
+                        message(name: 'Check Name', comments: 'Check Comments', enabled: false) eq 4096
+                        message('Check Name', comments: 'Check Comments', enabled: false) eq 4096
+                        message('Check Name') eq 4096
+                    }
+                }
+            }
+        }
+
+        File resultFile = tempFolder.newFile('assertions_2.jmx')
+
+        when: 'save test to file'
+        save(config, resultFile)
+
+        then: 'both files matches'
+        filesAreTheSame('assertions_2.jmx', resultFile)
+    }
+
+    def "Check assertion DSL with properties override generation"() {
+        expect: "configure test and save result to the file"
+        def config = configure {
+            plan {
+                group {
+                    check_response enabled: false, {
+                        status(enabled: true) ne 200, 'is not 2xx'
+                        status(enabled: false) ne 200, 'is not 2xx'
+                        status() ne 200, 'is not 2xx'
+
+                        headers(enabled: true) includes 'COOKIES', 'has cookies'
+                        headers(enabled: false) includes 'COOKIES', 'has cookies'
+                        headers() includes 'COOKIES', 'has cookies'
+
+                        text(enabled: true) includes 'test text'
+                        text(enabled: false) includes 'test text'
+                        text() includes 'test text'
+
+                        document(enabled: true) includes 'some text'
+                        document(enabled: false) includes 'some text'
+                        document() includes 'some text'
+
+
+                        message(enabled: true) eq 'OK', 'OK'
+                        message(enabled: false) eq 'OK', 'OK'
+                        message() eq 'OK', 'OK'
+
+
+                        url(enabled: true) includes 'localhost', 'local'
+                        url(enabled: false) includes 'localhost', 'local'
+                        url() includes 'localhost', 'local'
+
+                        duration(enabled: true) eq 2000
+                        duration(enabled: false) eq 2000
+                        duration() eq 2000
+
+                        md5hex(enabled: true) eq '2bf7b8126bb7c645638e444f6e2c58a5'
+                        md5hex(enabled: false) eq '2bf7b8126bb7c645638e444f6e2c58a5'
+                        md5hex() eq '2bf7b8126bb7c645638e444f6e2c58a5'
+                    }
+                    check_request enabled: false, {
+                        headers(enabled: true) includes 'COOKIES', 'has cookies'
+                        headers(enabled: false) includes 'COOKIES', 'has cookies'
+                        headers() includes 'COOKIES', 'has cookies'
+
+                        text(enabled: true) includes 'test text'
+                        text(enabled: false) includes 'test text'
+                        text() includes 'test text'
+                    }
+                    check_size enabled: false, {
+                        status(enabled: true) eq 4096
+                        status(enabled: false) eq 4096
+                        status() eq 4096
+
+                        headers(enabled: true) eq 4096
+                        headers(enabled: false) eq 4096
+                        headers() eq 4096
+
+                        text(enabled: true) eq 4096
+                        text(enabled: false) eq 4096
+                        text() eq 4096
+
+                        body(enabled: true) eq 4096
+                        body(enabled: false) eq 4096
+                        body() eq 4096
+
+                        message(enabled: true) eq 4096
+                        message(enabled: false) eq 4096
+                        message() eq 4096
+                    }
+                }
+            }
+        }
+
+        File resultFile = tempFolder.newFile('assertions_3.jmx')
+
+        when: 'save test to file'
+        save(config, resultFile)
+
+        then: 'both files matches'
+        filesAreTheSame('assertions_3.jmx', resultFile)
     }
 }

--- a/src/test/resources/net/simonix/dsl/jmeter/factory/assertion/assertions_0.jmx
+++ b/src/test/resources/net/simonix/dsl/jmeter/factory/assertion/assertions_0.jmx
@@ -135,7 +135,7 @@
           <stringProp name="Assertion.scope">all</stringProp>
           <stringProp name="Assertion.test_field">SizeAssertion.response_network_size</stringProp>
           <intProp name="SizeAssertion.operator">1</intProp>
-          <stringProp name="SizeAssertion.size">50</stringProp>
+          <stringProp name="SizeAssertion.size">4096</stringProp>
         </SizeAssertion>
         <hashTree/>
         <SizeAssertion guiclass="SizeAssertionGui" testclass="SizeAssertion" testname="Assert Size Factory" enabled="true">
@@ -143,14 +143,14 @@
           <stringProp name="Assertion.scope">all</stringProp>
           <stringProp name="Assertion.test_field">SizeAssertion.response_network_size</stringProp>
           <intProp name="SizeAssertion.operator">1</intProp>
-          <stringProp name="SizeAssertion.size">50</stringProp>
+          <stringProp name="SizeAssertion.size">4096</stringProp>
         </SizeAssertion>
         <hashTree/>
         <SizeAssertion guiclass="SizeAssertionGui" testclass="SizeAssertion" testname="Size Assertion" enabled="true">
           <stringProp name="Assertion.scope">all</stringProp>
           <stringProp name="Assertion.test_field">SizeAssertion.response_network_size</stringProp>
           <intProp name="SizeAssertion.operator">1</intProp>
-          <stringProp name="SizeAssertion.size">50</stringProp>
+          <stringProp name="SizeAssertion.size">4096</stringProp>
         </SizeAssertion>
         <hashTree/>
         <XPathAssertion guiclass="XPathAssertionGui" testclass="XPathAssertion" testname="XPath Assertion" enabled="true">

--- a/src/test/resources/net/simonix/dsl/jmeter/factory/assertion/assertions_2.jmx
+++ b/src/test/resources/net/simonix/dsl/jmeter/factory/assertion/assertions_2.jmx
@@ -44,7 +44,7 @@
         </elementProp>
       </ThreadGroup>
       <hashTree>
-        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Status" enabled="true">
+        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Name" enabled="false">
           <collectionProp name="Asserion.test_strings">
             <stringProp name="49586">200</stringProp>
             <stringProp name="49587">201</stringProp>
@@ -57,46 +57,7 @@
           <boolProp name="Assertion.assume_success">false</boolProp>
         </ResponseAssertion>
         <hashTree/>
-        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Status" enabled="true">
-          <collectionProp name="Asserion.test_strings">
-            <stringProp name="49617">210</stringProp>
-            <stringProp name="51570">420</stringProp>
-            <stringProp name="52562">530</stringProp>
-          </collectionProp>
-          <stringProp name="Assertion.scope">all</stringProp>
-          <stringProp name="Assertion.test_field">Assertion.response_code</stringProp>
-          <intProp name="Assertion.test_type">8</intProp>
-          <stringProp name="Assertion.custom_message"></stringProp>
-          <boolProp name="Assertion.assume_success">false</boolProp>
-        </ResponseAssertion>
-        <hashTree/>
-        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Status" enabled="true">
-          <collectionProp name="Asserion.test_strings">
-            <stringProp name="49587">201</stringProp>
-            <stringProp name="51510">402</stringProp>
-            <stringProp name="52472">503</stringProp>
-          </collectionProp>
-          <stringProp name="Assertion.scope">all</stringProp>
-          <stringProp name="Assertion.test_field">Assertion.response_code</stringProp>
-          <intProp name="Assertion.test_type">44</intProp>
-          <stringProp name="Assertion.custom_message"></stringProp>
-          <boolProp name="Assertion.assume_success">false</boolProp>
-        </ResponseAssertion>
-        <hashTree/>
-        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Status" enabled="true">
-          <collectionProp name="Asserion.test_strings">
-            <stringProp name="49617">210</stringProp>
-            <stringProp name="51570">420</stringProp>
-            <stringProp name="52562">530</stringProp>
-          </collectionProp>
-          <stringProp name="Assertion.scope">all</stringProp>
-          <stringProp name="Assertion.test_field">Assertion.response_code</stringProp>
-          <intProp name="Assertion.test_type">40</intProp>
-          <stringProp name="Assertion.custom_message"></stringProp>
-          <boolProp name="Assertion.assume_success">false</boolProp>
-        </ResponseAssertion>
-        <hashTree/>
-        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Status" enabled="true">
+        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Name" enabled="false">
           <collectionProp name="Asserion.test_strings">
             <stringProp name="52469">500</stringProp>
             <stringProp name="51508">400</stringProp>
@@ -108,31 +69,7 @@
           <boolProp name="Assertion.assume_success">false</boolProp>
         </ResponseAssertion>
         <hashTree/>
-        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Status" enabled="true">
-          <collectionProp name="Asserion.test_strings">
-            <stringProp name="52470">501</stringProp>
-            <stringProp name="51509">401</stringProp>
-          </collectionProp>
-          <stringProp name="Assertion.scope">all</stringProp>
-          <stringProp name="Assertion.test_field">Assertion.response_code</stringProp>
-          <intProp name="Assertion.test_type">48</intProp>
-          <stringProp name="Assertion.custom_message"></stringProp>
-          <boolProp name="Assertion.assume_success">false</boolProp>
-        </ResponseAssertion>
-        <hashTree/>
-        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Status" enabled="true">
-          <collectionProp name="Asserion.test_strings">
-            <stringProp name="-1670867693">pattern \d+</stringProp>
-            <stringProp name="-1148389980">test 123</stringProp>
-          </collectionProp>
-          <stringProp name="Assertion.scope">all</stringProp>
-          <stringProp name="Assertion.test_field">Assertion.response_code</stringProp>
-          <intProp name="Assertion.test_type">2</intProp>
-          <stringProp name="Assertion.custom_message">doesn&apos;t have email</stringProp>
-          <boolProp name="Assertion.assume_success">false</boolProp>
-        </ResponseAssertion>
-        <hashTree/>
-        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Status" enabled="true">
+        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Name" enabled="false">
           <collectionProp name="Asserion.test_strings">
             <stringProp name="-1670867693">pattern \d+</stringProp>
             <stringProp name="-1148389980">test 123</stringProp>
@@ -144,7 +81,7 @@
           <boolProp name="Assertion.assume_success">false</boolProp>
         </ResponseAssertion>
         <hashTree/>
-        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Status" enabled="true">
+        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Name" enabled="false">
           <collectionProp name="Asserion.test_strings">
             <stringProp name="-1670867693">pattern \d+</stringProp>
             <stringProp name="-1148389980">test 123</stringProp>
@@ -156,30 +93,31 @@
           <boolProp name="Assertion.assume_success">false</boolProp>
         </ResponseAssertion>
         <hashTree/>
-        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Status" enabled="true">
+        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Name" enabled="false">
           <collectionProp name="Asserion.test_strings">
             <stringProp name="-1670867693">pattern \d+</stringProp>
             <stringProp name="-1148389980">test 123</stringProp>
           </collectionProp>
           <stringProp name="Assertion.scope">all</stringProp>
           <stringProp name="Assertion.test_field">Assertion.response_code</stringProp>
-          <intProp name="Assertion.test_type">33</intProp>
+          <intProp name="Assertion.test_type">1</intProp>
           <stringProp name="Assertion.custom_message"></stringProp>
           <boolProp name="Assertion.assume_success">false</boolProp>
         </ResponseAssertion>
         <hashTree/>
-        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Headers" enabled="true">
+        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Name" enabled="true">
           <collectionProp name="Asserion.test_strings">
-            <stringProp name="1670172271">COOKIES</stringProp>
+            <stringProp name="-1670867693">pattern \d+</stringProp>
+            <stringProp name="-1148389980">test 123</stringProp>
           </collectionProp>
           <stringProp name="Assertion.scope">all</stringProp>
-          <stringProp name="Assertion.test_field">Assertion.response_headers</stringProp>
-          <intProp name="Assertion.test_type">6</intProp>
-          <stringProp name="Assertion.custom_message">no cookies</stringProp>
+          <stringProp name="Assertion.test_field">Assertion.response_code</stringProp>
+          <intProp name="Assertion.test_type">1</intProp>
+          <stringProp name="Assertion.custom_message"></stringProp>
           <boolProp name="Assertion.assume_success">false</boolProp>
         </ResponseAssertion>
         <hashTree/>
-        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Headers" enabled="true">
+        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Name" enabled="false">
           <collectionProp name="Asserion.test_strings">
             <stringProp name="1670172271">COOKIES</stringProp>
           </collectionProp>
@@ -190,18 +128,29 @@
           <boolProp name="Assertion.assume_success">false</boolProp>
         </ResponseAssertion>
         <hashTree/>
-        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Text" enabled="true">
+        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Name" enabled="false">
           <collectionProp name="Asserion.test_strings">
-            <stringProp name="-1238303749">test text</stringProp>
+            <stringProp name="1670172271">COOKIES</stringProp>
           </collectionProp>
           <stringProp name="Assertion.scope">all</stringProp>
-          <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
-          <intProp name="Assertion.test_type">6</intProp>
-          <stringProp name="Assertion.custom_message"></stringProp>
+          <stringProp name="Assertion.test_field">Assertion.response_headers</stringProp>
+          <intProp name="Assertion.test_type">2</intProp>
+          <stringProp name="Assertion.custom_message">has cookies</stringProp>
           <boolProp name="Assertion.assume_success">false</boolProp>
         </ResponseAssertion>
         <hashTree/>
-        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Text" enabled="true">
+        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Name" enabled="true">
+          <collectionProp name="Asserion.test_strings">
+            <stringProp name="1670172271">COOKIES</stringProp>
+          </collectionProp>
+          <stringProp name="Assertion.scope">all</stringProp>
+          <stringProp name="Assertion.test_field">Assertion.response_headers</stringProp>
+          <intProp name="Assertion.test_type">2</intProp>
+          <stringProp name="Assertion.custom_message">has cookies</stringProp>
+          <boolProp name="Assertion.assume_success">false</boolProp>
+        </ResponseAssertion>
+        <hashTree/>
+        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Name" enabled="false">
           <collectionProp name="Asserion.test_strings">
             <stringProp name="-1238303749">test text</stringProp>
           </collectionProp>
@@ -212,18 +161,29 @@
           <boolProp name="Assertion.assume_success">false</boolProp>
         </ResponseAssertion>
         <hashTree/>
-        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Document" enabled="true">
+        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Name" enabled="false">
           <collectionProp name="Asserion.test_strings">
-            <stringProp name="-642107175">some text</stringProp>
+            <stringProp name="-1238303749">test text</stringProp>
           </collectionProp>
           <stringProp name="Assertion.scope">all</stringProp>
-          <stringProp name="Assertion.test_field">Assertion.response_data_as_document</stringProp>
-          <intProp name="Assertion.test_type">6</intProp>
+          <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
+          <intProp name="Assertion.test_type">2</intProp>
           <stringProp name="Assertion.custom_message"></stringProp>
           <boolProp name="Assertion.assume_success">false</boolProp>
         </ResponseAssertion>
         <hashTree/>
-        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Document" enabled="true">
+        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Name" enabled="true">
+          <collectionProp name="Asserion.test_strings">
+            <stringProp name="-1238303749">test text</stringProp>
+          </collectionProp>
+          <stringProp name="Assertion.scope">all</stringProp>
+          <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
+          <intProp name="Assertion.test_type">2</intProp>
+          <stringProp name="Assertion.custom_message"></stringProp>
+          <boolProp name="Assertion.assume_success">false</boolProp>
+        </ResponseAssertion>
+        <hashTree/>
+        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Name" enabled="false">
           <collectionProp name="Asserion.test_strings">
             <stringProp name="-642107175">some text</stringProp>
           </collectionProp>
@@ -234,18 +194,29 @@
           <boolProp name="Assertion.assume_success">false</boolProp>
         </ResponseAssertion>
         <hashTree/>
-        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Message" enabled="true">
+        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Name" enabled="false">
           <collectionProp name="Asserion.test_strings">
-            <stringProp name="2524">OK</stringProp>
+            <stringProp name="-642107175">some text</stringProp>
           </collectionProp>
           <stringProp name="Assertion.scope">all</stringProp>
-          <stringProp name="Assertion.test_field">Assertion.response_message</stringProp>
-          <intProp name="Assertion.test_type">12</intProp>
-          <stringProp name="Assertion.custom_message">Not OK</stringProp>
+          <stringProp name="Assertion.test_field">Assertion.response_data_as_document</stringProp>
+          <intProp name="Assertion.test_type">2</intProp>
+          <stringProp name="Assertion.custom_message"></stringProp>
           <boolProp name="Assertion.assume_success">false</boolProp>
         </ResponseAssertion>
         <hashTree/>
-        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Message" enabled="true">
+        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Name" enabled="true">
+          <collectionProp name="Asserion.test_strings">
+            <stringProp name="-642107175">some text</stringProp>
+          </collectionProp>
+          <stringProp name="Assertion.scope">all</stringProp>
+          <stringProp name="Assertion.test_field">Assertion.response_data_as_document</stringProp>
+          <intProp name="Assertion.test_type">2</intProp>
+          <stringProp name="Assertion.custom_message"></stringProp>
+          <boolProp name="Assertion.assume_success">false</boolProp>
+        </ResponseAssertion>
+        <hashTree/>
+        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Name" enabled="false">
           <collectionProp name="Asserion.test_strings">
             <stringProp name="2524">OK</stringProp>
           </collectionProp>
@@ -256,18 +227,29 @@
           <boolProp name="Assertion.assume_success">false</boolProp>
         </ResponseAssertion>
         <hashTree/>
-        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Url" enabled="true">
+        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Name" enabled="false">
           <collectionProp name="Asserion.test_strings">
-            <stringProp name="-1204607085">localhost</stringProp>
+            <stringProp name="2524">OK</stringProp>
           </collectionProp>
           <stringProp name="Assertion.scope">all</stringProp>
-          <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
-          <intProp name="Assertion.test_type">6</intProp>
-          <stringProp name="Assertion.custom_message">external</stringProp>
+          <stringProp name="Assertion.test_field">Assertion.response_message</stringProp>
+          <intProp name="Assertion.test_type">8</intProp>
+          <stringProp name="Assertion.custom_message">OK</stringProp>
           <boolProp name="Assertion.assume_success">false</boolProp>
         </ResponseAssertion>
         <hashTree/>
-        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Url" enabled="true">
+        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Name" enabled="true">
+          <collectionProp name="Asserion.test_strings">
+            <stringProp name="2524">OK</stringProp>
+          </collectionProp>
+          <stringProp name="Assertion.scope">all</stringProp>
+          <stringProp name="Assertion.test_field">Assertion.response_message</stringProp>
+          <intProp name="Assertion.test_type">8</intProp>
+          <stringProp name="Assertion.custom_message">OK</stringProp>
+          <boolProp name="Assertion.assume_success">false</boolProp>
+        </ResponseAssertion>
+        <hashTree/>
+        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Name" enabled="false">
           <collectionProp name="Asserion.test_strings">
             <stringProp name="-1204607085">localhost</stringProp>
           </collectionProp>
@@ -278,27 +260,56 @@
           <boolProp name="Assertion.assume_success">false</boolProp>
         </ResponseAssertion>
         <hashTree/>
-        <DurationAssertion guiclass="DurationAssertionGui" testclass="DurationAssertion" testname="Check Duration" enabled="true">
+        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Name" enabled="false">
+          <collectionProp name="Asserion.test_strings">
+            <stringProp name="-1204607085">localhost</stringProp>
+          </collectionProp>
+          <stringProp name="Assertion.scope">all</stringProp>
+          <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
+          <intProp name="Assertion.test_type">2</intProp>
+          <stringProp name="Assertion.custom_message">local</stringProp>
+          <boolProp name="Assertion.assume_success">false</boolProp>
+        </ResponseAssertion>
+        <hashTree/>
+        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Name" enabled="true">
+          <collectionProp name="Asserion.test_strings">
+            <stringProp name="-1204607085">localhost</stringProp>
+          </collectionProp>
+          <stringProp name="Assertion.scope">all</stringProp>
+          <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
+          <intProp name="Assertion.test_type">2</intProp>
+          <stringProp name="Assertion.custom_message">local</stringProp>
+          <boolProp name="Assertion.assume_success">false</boolProp>
+        </ResponseAssertion>
+        <hashTree/>
+        <DurationAssertion guiclass="DurationAssertionGui" testclass="DurationAssertion" testname="Check Name" enabled="false">
           <stringProp name="Assertion.scope">all</stringProp>
           <longProp name="DurationAssertion.duration">2000</longProp>
         </DurationAssertion>
         <hashTree/>
-        <MD5HexAssertion guiclass="MD5HexAssertionGUI" testclass="MD5HexAssertion" testname="Check MD5Hex" enabled="true">
+        <DurationAssertion guiclass="DurationAssertionGui" testclass="DurationAssertion" testname="Check Name" enabled="false">
+          <stringProp name="Assertion.scope">all</stringProp>
+          <longProp name="DurationAssertion.duration">2000</longProp>
+        </DurationAssertion>
+        <hashTree/>
+        <DurationAssertion guiclass="DurationAssertionGui" testclass="DurationAssertion" testname="Check Name" enabled="true">
+          <stringProp name="Assertion.scope">all</stringProp>
+          <longProp name="DurationAssertion.duration">2000</longProp>
+        </DurationAssertion>
+        <hashTree/>
+        <MD5HexAssertion guiclass="MD5HexAssertionGUI" testclass="MD5HexAssertion" testname="Check Name" enabled="false">
           <stringProp name="MD5HexAssertion.size">2bf7b8126bb7c645638e444f6e2c58a5</stringProp>
         </MD5HexAssertion>
         <hashTree/>
-        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Headers" enabled="true">
-          <collectionProp name="Asserion.test_strings">
-            <stringProp name="1670172271">COOKIES</stringProp>
-          </collectionProp>
-          <stringProp name="Assertion.scope">all</stringProp>
-          <stringProp name="Assertion.test_field">Assertion.request_headers</stringProp>
-          <intProp name="Assertion.test_type">6</intProp>
-          <stringProp name="Assertion.custom_message">no cookies</stringProp>
-          <boolProp name="Assertion.assume_success">false</boolProp>
-        </ResponseAssertion>
+        <MD5HexAssertion guiclass="MD5HexAssertionGUI" testclass="MD5HexAssertion" testname="Check Name" enabled="false">
+          <stringProp name="MD5HexAssertion.size">2bf7b8126bb7c645638e444f6e2c58a5</stringProp>
+        </MD5HexAssertion>
         <hashTree/>
-        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Headers" enabled="true">
+        <MD5HexAssertion guiclass="MD5HexAssertionGUI" testclass="MD5HexAssertion" testname="Check Name" enabled="true">
+          <stringProp name="MD5HexAssertion.size">2bf7b8126bb7c645638e444f6e2c58a5</stringProp>
+        </MD5HexAssertion>
+        <hashTree/>
+        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Name" enabled="false">
           <collectionProp name="Asserion.test_strings">
             <stringProp name="1670172271">COOKIES</stringProp>
           </collectionProp>
@@ -309,18 +320,29 @@
           <boolProp name="Assertion.assume_success">false</boolProp>
         </ResponseAssertion>
         <hashTree/>
-        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Text" enabled="true">
+        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Name" enabled="false">
           <collectionProp name="Asserion.test_strings">
-            <stringProp name="-1238303749">test text</stringProp>
+            <stringProp name="1670172271">COOKIES</stringProp>
           </collectionProp>
           <stringProp name="Assertion.scope">all</stringProp>
-          <stringProp name="Assertion.test_field">Assertion.request_data</stringProp>
-          <intProp name="Assertion.test_type">6</intProp>
-          <stringProp name="Assertion.custom_message"></stringProp>
+          <stringProp name="Assertion.test_field">Assertion.request_headers</stringProp>
+          <intProp name="Assertion.test_type">2</intProp>
+          <stringProp name="Assertion.custom_message">has cookies</stringProp>
           <boolProp name="Assertion.assume_success">false</boolProp>
         </ResponseAssertion>
         <hashTree/>
-        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Text" enabled="true">
+        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Name" enabled="true">
+          <collectionProp name="Asserion.test_strings">
+            <stringProp name="1670172271">COOKIES</stringProp>
+          </collectionProp>
+          <stringProp name="Assertion.scope">all</stringProp>
+          <stringProp name="Assertion.test_field">Assertion.request_headers</stringProp>
+          <intProp name="Assertion.test_type">2</intProp>
+          <stringProp name="Assertion.custom_message">has cookies</stringProp>
+          <boolProp name="Assertion.assume_success">false</boolProp>
+        </ResponseAssertion>
+        <hashTree/>
+        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Name" enabled="false">
           <collectionProp name="Asserion.test_strings">
             <stringProp name="-1238303749">test text</stringProp>
           </collectionProp>
@@ -331,70 +353,127 @@
           <boolProp name="Assertion.assume_success">false</boolProp>
         </ResponseAssertion>
         <hashTree/>
-        <SizeAssertion guiclass="SizeAssertionGui" testclass="SizeAssertion" testname="Check Size" enabled="true">
+        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Name" enabled="false">
+          <collectionProp name="Asserion.test_strings">
+            <stringProp name="-1238303749">test text</stringProp>
+          </collectionProp>
+          <stringProp name="Assertion.scope">all</stringProp>
+          <stringProp name="Assertion.test_field">Assertion.request_data</stringProp>
+          <intProp name="Assertion.test_type">2</intProp>
+          <stringProp name="Assertion.custom_message"></stringProp>
+          <boolProp name="Assertion.assume_success">false</boolProp>
+        </ResponseAssertion>
+        <hashTree/>
+        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Name" enabled="true">
+          <collectionProp name="Asserion.test_strings">
+            <stringProp name="-1238303749">test text</stringProp>
+          </collectionProp>
+          <stringProp name="Assertion.scope">all</stringProp>
+          <stringProp name="Assertion.test_field">Assertion.request_data</stringProp>
+          <intProp name="Assertion.test_type">2</intProp>
+          <stringProp name="Assertion.custom_message"></stringProp>
+          <boolProp name="Assertion.assume_success">false</boolProp>
+        </ResponseAssertion>
+        <hashTree/>
+        <SizeAssertion guiclass="SizeAssertionGui" testclass="SizeAssertion" testname="Check Name" enabled="false">
           <stringProp name="Assertion.scope">all</stringProp>
           <stringProp name="Assertion.test_field">SizeAssertion.response_network_size</stringProp>
           <intProp name="SizeAssertion.operator">1</intProp>
           <stringProp name="SizeAssertion.size">4096</stringProp>
         </SizeAssertion>
         <hashTree/>
-        <SizeAssertion guiclass="SizeAssertionGui" testclass="SizeAssertion" testname="Check Size" enabled="true">
+        <SizeAssertion guiclass="SizeAssertionGui" testclass="SizeAssertion" testname="Check Name" enabled="false">
           <stringProp name="Assertion.scope">all</stringProp>
           <stringProp name="Assertion.test_field">SizeAssertion.response_network_size</stringProp>
-          <intProp name="SizeAssertion.operator">2</intProp>
+          <intProp name="SizeAssertion.operator">1</intProp>
           <stringProp name="SizeAssertion.size">4096</stringProp>
         </SizeAssertion>
         <hashTree/>
-        <SizeAssertion guiclass="SizeAssertionGui" testclass="SizeAssertion" testname="Check Size" enabled="true">
+        <SizeAssertion guiclass="SizeAssertionGui" testclass="SizeAssertion" testname="Check Name" enabled="true">
           <stringProp name="Assertion.scope">all</stringProp>
           <stringProp name="Assertion.test_field">SizeAssertion.response_network_size</stringProp>
-          <intProp name="SizeAssertion.operator">3</intProp>
+          <intProp name="SizeAssertion.operator">1</intProp>
           <stringProp name="SizeAssertion.size">4096</stringProp>
         </SizeAssertion>
         <hashTree/>
-        <SizeAssertion guiclass="SizeAssertionGui" testclass="SizeAssertion" testname="Check Size" enabled="true">
-          <stringProp name="Assertion.scope">all</stringProp>
-          <stringProp name="Assertion.test_field">SizeAssertion.response_network_size</stringProp>
-          <intProp name="SizeAssertion.operator">4</intProp>
-          <stringProp name="SizeAssertion.size">4096</stringProp>
-        </SizeAssertion>
-        <hashTree/>
-        <SizeAssertion guiclass="SizeAssertionGui" testclass="SizeAssertion" testname="Check Size" enabled="true">
-          <stringProp name="Assertion.scope">all</stringProp>
-          <stringProp name="Assertion.test_field">SizeAssertion.response_network_size</stringProp>
-          <intProp name="SizeAssertion.operator">5</intProp>
-          <stringProp name="SizeAssertion.size">4096</stringProp>
-        </SizeAssertion>
-        <hashTree/>
-        <SizeAssertion guiclass="SizeAssertionGui" testclass="SizeAssertion" testname="Check Size" enabled="true">
-          <stringProp name="Assertion.scope">all</stringProp>
-          <stringProp name="Assertion.test_field">SizeAssertion.response_network_size</stringProp>
-          <intProp name="SizeAssertion.operator">6</intProp>
-          <stringProp name="SizeAssertion.size">4096</stringProp>
-        </SizeAssertion>
-        <hashTree/>
-        <SizeAssertion guiclass="SizeAssertionGui" testclass="SizeAssertion" testname="Check Size" enabled="true">
+        <SizeAssertion guiclass="SizeAssertionGui" testclass="SizeAssertion" testname="Check Name" enabled="false">
           <stringProp name="Assertion.scope">all</stringProp>
           <stringProp name="Assertion.test_field">SizeAssertion.response_headers</stringProp>
           <intProp name="SizeAssertion.operator">1</intProp>
           <stringProp name="SizeAssertion.size">4096</stringProp>
         </SizeAssertion>
         <hashTree/>
-        <SizeAssertion guiclass="SizeAssertionGui" testclass="SizeAssertion" testname="Check Size" enabled="true">
+        <SizeAssertion guiclass="SizeAssertionGui" testclass="SizeAssertion" testname="Check Name" enabled="false">
+          <stringProp name="Assertion.scope">all</stringProp>
+          <stringProp name="Assertion.test_field">SizeAssertion.response_headers</stringProp>
+          <intProp name="SizeAssertion.operator">1</intProp>
+          <stringProp name="SizeAssertion.size">4096</stringProp>
+        </SizeAssertion>
+        <hashTree/>
+        <SizeAssertion guiclass="SizeAssertionGui" testclass="SizeAssertion" testname="Check Name" enabled="true">
+          <stringProp name="Assertion.scope">all</stringProp>
+          <stringProp name="Assertion.test_field">SizeAssertion.response_headers</stringProp>
+          <intProp name="SizeAssertion.operator">1</intProp>
+          <stringProp name="SizeAssertion.size">4096</stringProp>
+        </SizeAssertion>
+        <hashTree/>
+        <SizeAssertion guiclass="SizeAssertionGui" testclass="SizeAssertion" testname="Check Name" enabled="false">
           <stringProp name="Assertion.scope">all</stringProp>
           <stringProp name="Assertion.test_field">SizeAssertion.response_network_size</stringProp>
           <intProp name="SizeAssertion.operator">1</intProp>
           <stringProp name="SizeAssertion.size">4096</stringProp>
         </SizeAssertion>
         <hashTree/>
-        <SizeAssertion guiclass="SizeAssertionGui" testclass="SizeAssertion" testname="Check Size" enabled="true">
+        <SizeAssertion guiclass="SizeAssertionGui" testclass="SizeAssertion" testname="Check Name" enabled="false">
+          <stringProp name="Assertion.scope">all</stringProp>
+          <stringProp name="Assertion.test_field">SizeAssertion.response_network_size</stringProp>
+          <intProp name="SizeAssertion.operator">1</intProp>
+          <stringProp name="SizeAssertion.size">4096</stringProp>
+        </SizeAssertion>
+        <hashTree/>
+        <SizeAssertion guiclass="SizeAssertionGui" testclass="SizeAssertion" testname="Check Name" enabled="true">
+          <stringProp name="Assertion.scope">all</stringProp>
+          <stringProp name="Assertion.test_field">SizeAssertion.response_network_size</stringProp>
+          <intProp name="SizeAssertion.operator">1</intProp>
+          <stringProp name="SizeAssertion.size">4096</stringProp>
+        </SizeAssertion>
+        <hashTree/>
+        <SizeAssertion guiclass="SizeAssertionGui" testclass="SizeAssertion" testname="Check Name" enabled="false">
           <stringProp name="Assertion.scope">all</stringProp>
           <stringProp name="Assertion.test_field">SizeAssertion.response_data</stringProp>
           <intProp name="SizeAssertion.operator">1</intProp>
           <stringProp name="SizeAssertion.size">4096</stringProp>
         </SizeAssertion>
         <hashTree/>
-        <SizeAssertion guiclass="SizeAssertionGui" testclass="SizeAssertion" testname="Check Size" enabled="true">
+        <SizeAssertion guiclass="SizeAssertionGui" testclass="SizeAssertion" testname="Check Name" enabled="false">
+          <stringProp name="Assertion.scope">all</stringProp>
+          <stringProp name="Assertion.test_field">SizeAssertion.response_data</stringProp>
+          <intProp name="SizeAssertion.operator">1</intProp>
+          <stringProp name="SizeAssertion.size">4096</stringProp>
+        </SizeAssertion>
+        <hashTree/>
+        <SizeAssertion guiclass="SizeAssertionGui" testclass="SizeAssertion" testname="Check Name" enabled="true">
+          <stringProp name="Assertion.scope">all</stringProp>
+          <stringProp name="Assertion.test_field">SizeAssertion.response_data</stringProp>
+          <intProp name="SizeAssertion.operator">1</intProp>
+          <stringProp name="SizeAssertion.size">4096</stringProp>
+        </SizeAssertion>
+        <hashTree/>
+        <SizeAssertion guiclass="SizeAssertionGui" testclass="SizeAssertion" testname="Check Name" enabled="false">
+          <stringProp name="Assertion.scope">all</stringProp>
+          <stringProp name="Assertion.test_field">SizeAssertion.response_message</stringProp>
+          <intProp name="SizeAssertion.operator">1</intProp>
+          <stringProp name="SizeAssertion.size">4096</stringProp>
+        </SizeAssertion>
+        <hashTree/>
+        <SizeAssertion guiclass="SizeAssertionGui" testclass="SizeAssertion" testname="Check Name" enabled="false">
+          <stringProp name="Assertion.scope">all</stringProp>
+          <stringProp name="Assertion.test_field">SizeAssertion.response_message</stringProp>
+          <intProp name="SizeAssertion.operator">1</intProp>
+          <stringProp name="SizeAssertion.size">4096</stringProp>
+        </SizeAssertion>
+        <hashTree/>
+        <SizeAssertion guiclass="SizeAssertionGui" testclass="SizeAssertion" testname="Check Name" enabled="true">
           <stringProp name="Assertion.scope">all</stringProp>
           <stringProp name="Assertion.test_field">SizeAssertion.response_message</stringProp>
           <intProp name="SizeAssertion.operator">1</intProp>

--- a/src/test/resources/net/simonix/dsl/jmeter/factory/assertion/assertions_3.jmx
+++ b/src/test/resources/net/simonix/dsl/jmeter/factory/assertion/assertions_3.jmx
@@ -47,8 +47,6 @@
         <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Status" enabled="true">
           <collectionProp name="Asserion.test_strings">
             <stringProp name="49586">200</stringProp>
-            <stringProp name="49587">201</stringProp>
-            <stringProp name="49588">202</stringProp>
           </collectionProp>
           <stringProp name="Assertion.scope">all</stringProp>
           <stringProp name="Assertion.test_field">Assertion.response_code</stringProp>
@@ -57,114 +55,25 @@
           <boolProp name="Assertion.assume_success">false</boolProp>
         </ResponseAssertion>
         <hashTree/>
-        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Status" enabled="true">
+        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Status" enabled="false">
           <collectionProp name="Asserion.test_strings">
-            <stringProp name="49617">210</stringProp>
-            <stringProp name="51570">420</stringProp>
-            <stringProp name="52562">530</stringProp>
+            <stringProp name="49586">200</stringProp>
           </collectionProp>
           <stringProp name="Assertion.scope">all</stringProp>
           <stringProp name="Assertion.test_field">Assertion.response_code</stringProp>
-          <intProp name="Assertion.test_type">8</intProp>
-          <stringProp name="Assertion.custom_message"></stringProp>
+          <intProp name="Assertion.test_type">12</intProp>
+          <stringProp name="Assertion.custom_message">is not 2xx</stringProp>
           <boolProp name="Assertion.assume_success">false</boolProp>
         </ResponseAssertion>
         <hashTree/>
-        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Status" enabled="true">
+        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Status" enabled="false">
           <collectionProp name="Asserion.test_strings">
-            <stringProp name="49587">201</stringProp>
-            <stringProp name="51510">402</stringProp>
-            <stringProp name="52472">503</stringProp>
+            <stringProp name="49586">200</stringProp>
           </collectionProp>
           <stringProp name="Assertion.scope">all</stringProp>
           <stringProp name="Assertion.test_field">Assertion.response_code</stringProp>
-          <intProp name="Assertion.test_type">44</intProp>
-          <stringProp name="Assertion.custom_message"></stringProp>
-          <boolProp name="Assertion.assume_success">false</boolProp>
-        </ResponseAssertion>
-        <hashTree/>
-        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Status" enabled="true">
-          <collectionProp name="Asserion.test_strings">
-            <stringProp name="49617">210</stringProp>
-            <stringProp name="51570">420</stringProp>
-            <stringProp name="52562">530</stringProp>
-          </collectionProp>
-          <stringProp name="Assertion.scope">all</stringProp>
-          <stringProp name="Assertion.test_field">Assertion.response_code</stringProp>
-          <intProp name="Assertion.test_type">40</intProp>
-          <stringProp name="Assertion.custom_message"></stringProp>
-          <boolProp name="Assertion.assume_success">false</boolProp>
-        </ResponseAssertion>
-        <hashTree/>
-        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Status" enabled="true">
-          <collectionProp name="Asserion.test_strings">
-            <stringProp name="52469">500</stringProp>
-            <stringProp name="51508">400</stringProp>
-          </collectionProp>
-          <stringProp name="Assertion.scope">all</stringProp>
-          <stringProp name="Assertion.test_field">Assertion.response_code</stringProp>
-          <intProp name="Assertion.test_type">16</intProp>
-          <stringProp name="Assertion.custom_message"></stringProp>
-          <boolProp name="Assertion.assume_success">false</boolProp>
-        </ResponseAssertion>
-        <hashTree/>
-        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Status" enabled="true">
-          <collectionProp name="Asserion.test_strings">
-            <stringProp name="52470">501</stringProp>
-            <stringProp name="51509">401</stringProp>
-          </collectionProp>
-          <stringProp name="Assertion.scope">all</stringProp>
-          <stringProp name="Assertion.test_field">Assertion.response_code</stringProp>
-          <intProp name="Assertion.test_type">48</intProp>
-          <stringProp name="Assertion.custom_message"></stringProp>
-          <boolProp name="Assertion.assume_success">false</boolProp>
-        </ResponseAssertion>
-        <hashTree/>
-        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Status" enabled="true">
-          <collectionProp name="Asserion.test_strings">
-            <stringProp name="-1670867693">pattern \d+</stringProp>
-            <stringProp name="-1148389980">test 123</stringProp>
-          </collectionProp>
-          <stringProp name="Assertion.scope">all</stringProp>
-          <stringProp name="Assertion.test_field">Assertion.response_code</stringProp>
-          <intProp name="Assertion.test_type">2</intProp>
-          <stringProp name="Assertion.custom_message">doesn&apos;t have email</stringProp>
-          <boolProp name="Assertion.assume_success">false</boolProp>
-        </ResponseAssertion>
-        <hashTree/>
-        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Status" enabled="true">
-          <collectionProp name="Asserion.test_strings">
-            <stringProp name="-1670867693">pattern \d+</stringProp>
-            <stringProp name="-1148389980">test 123</stringProp>
-          </collectionProp>
-          <stringProp name="Assertion.scope">all</stringProp>
-          <stringProp name="Assertion.test_field">Assertion.response_code</stringProp>
-          <intProp name="Assertion.test_type">34</intProp>
-          <stringProp name="Assertion.custom_message"></stringProp>
-          <boolProp name="Assertion.assume_success">false</boolProp>
-        </ResponseAssertion>
-        <hashTree/>
-        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Status" enabled="true">
-          <collectionProp name="Asserion.test_strings">
-            <stringProp name="-1670867693">pattern \d+</stringProp>
-            <stringProp name="-1148389980">test 123</stringProp>
-          </collectionProp>
-          <stringProp name="Assertion.scope">all</stringProp>
-          <stringProp name="Assertion.test_field">Assertion.response_code</stringProp>
-          <intProp name="Assertion.test_type">1</intProp>
-          <stringProp name="Assertion.custom_message"></stringProp>
-          <boolProp name="Assertion.assume_success">false</boolProp>
-        </ResponseAssertion>
-        <hashTree/>
-        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Status" enabled="true">
-          <collectionProp name="Asserion.test_strings">
-            <stringProp name="-1670867693">pattern \d+</stringProp>
-            <stringProp name="-1148389980">test 123</stringProp>
-          </collectionProp>
-          <stringProp name="Assertion.scope">all</stringProp>
-          <stringProp name="Assertion.test_field">Assertion.response_code</stringProp>
-          <intProp name="Assertion.test_type">33</intProp>
-          <stringProp name="Assertion.custom_message"></stringProp>
+          <intProp name="Assertion.test_type">12</intProp>
+          <stringProp name="Assertion.custom_message">is not 2xx</stringProp>
           <boolProp name="Assertion.assume_success">false</boolProp>
         </ResponseAssertion>
         <hashTree/>
@@ -174,12 +83,23 @@
           </collectionProp>
           <stringProp name="Assertion.scope">all</stringProp>
           <stringProp name="Assertion.test_field">Assertion.response_headers</stringProp>
-          <intProp name="Assertion.test_type">6</intProp>
-          <stringProp name="Assertion.custom_message">no cookies</stringProp>
+          <intProp name="Assertion.test_type">2</intProp>
+          <stringProp name="Assertion.custom_message">has cookies</stringProp>
           <boolProp name="Assertion.assume_success">false</boolProp>
         </ResponseAssertion>
         <hashTree/>
-        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Headers" enabled="true">
+        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Headers" enabled="false">
+          <collectionProp name="Asserion.test_strings">
+            <stringProp name="1670172271">COOKIES</stringProp>
+          </collectionProp>
+          <stringProp name="Assertion.scope">all</stringProp>
+          <stringProp name="Assertion.test_field">Assertion.response_headers</stringProp>
+          <intProp name="Assertion.test_type">2</intProp>
+          <stringProp name="Assertion.custom_message">has cookies</stringProp>
+          <boolProp name="Assertion.assume_success">false</boolProp>
+        </ResponseAssertion>
+        <hashTree/>
+        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Headers" enabled="false">
           <collectionProp name="Asserion.test_strings">
             <stringProp name="1670172271">COOKIES</stringProp>
           </collectionProp>
@@ -196,12 +116,23 @@
           </collectionProp>
           <stringProp name="Assertion.scope">all</stringProp>
           <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
-          <intProp name="Assertion.test_type">6</intProp>
+          <intProp name="Assertion.test_type">2</intProp>
           <stringProp name="Assertion.custom_message"></stringProp>
           <boolProp name="Assertion.assume_success">false</boolProp>
         </ResponseAssertion>
         <hashTree/>
-        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Text" enabled="true">
+        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Text" enabled="false">
+          <collectionProp name="Asserion.test_strings">
+            <stringProp name="-1238303749">test text</stringProp>
+          </collectionProp>
+          <stringProp name="Assertion.scope">all</stringProp>
+          <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
+          <intProp name="Assertion.test_type">2</intProp>
+          <stringProp name="Assertion.custom_message"></stringProp>
+          <boolProp name="Assertion.assume_success">false</boolProp>
+        </ResponseAssertion>
+        <hashTree/>
+        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Text" enabled="false">
           <collectionProp name="Asserion.test_strings">
             <stringProp name="-1238303749">test text</stringProp>
           </collectionProp>
@@ -218,12 +149,23 @@
           </collectionProp>
           <stringProp name="Assertion.scope">all</stringProp>
           <stringProp name="Assertion.test_field">Assertion.response_data_as_document</stringProp>
-          <intProp name="Assertion.test_type">6</intProp>
+          <intProp name="Assertion.test_type">2</intProp>
           <stringProp name="Assertion.custom_message"></stringProp>
           <boolProp name="Assertion.assume_success">false</boolProp>
         </ResponseAssertion>
         <hashTree/>
-        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Document" enabled="true">
+        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Document" enabled="false">
+          <collectionProp name="Asserion.test_strings">
+            <stringProp name="-642107175">some text</stringProp>
+          </collectionProp>
+          <stringProp name="Assertion.scope">all</stringProp>
+          <stringProp name="Assertion.test_field">Assertion.response_data_as_document</stringProp>
+          <intProp name="Assertion.test_type">2</intProp>
+          <stringProp name="Assertion.custom_message"></stringProp>
+          <boolProp name="Assertion.assume_success">false</boolProp>
+        </ResponseAssertion>
+        <hashTree/>
+        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Document" enabled="false">
           <collectionProp name="Asserion.test_strings">
             <stringProp name="-642107175">some text</stringProp>
           </collectionProp>
@@ -240,12 +182,23 @@
           </collectionProp>
           <stringProp name="Assertion.scope">all</stringProp>
           <stringProp name="Assertion.test_field">Assertion.response_message</stringProp>
-          <intProp name="Assertion.test_type">12</intProp>
-          <stringProp name="Assertion.custom_message">Not OK</stringProp>
+          <intProp name="Assertion.test_type">8</intProp>
+          <stringProp name="Assertion.custom_message">OK</stringProp>
           <boolProp name="Assertion.assume_success">false</boolProp>
         </ResponseAssertion>
         <hashTree/>
-        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Message" enabled="true">
+        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Message" enabled="false">
+          <collectionProp name="Asserion.test_strings">
+            <stringProp name="2524">OK</stringProp>
+          </collectionProp>
+          <stringProp name="Assertion.scope">all</stringProp>
+          <stringProp name="Assertion.test_field">Assertion.response_message</stringProp>
+          <intProp name="Assertion.test_type">8</intProp>
+          <stringProp name="Assertion.custom_message">OK</stringProp>
+          <boolProp name="Assertion.assume_success">false</boolProp>
+        </ResponseAssertion>
+        <hashTree/>
+        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Message" enabled="false">
           <collectionProp name="Asserion.test_strings">
             <stringProp name="2524">OK</stringProp>
           </collectionProp>
@@ -262,12 +215,23 @@
           </collectionProp>
           <stringProp name="Assertion.scope">all</stringProp>
           <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
-          <intProp name="Assertion.test_type">6</intProp>
-          <stringProp name="Assertion.custom_message">external</stringProp>
+          <intProp name="Assertion.test_type">2</intProp>
+          <stringProp name="Assertion.custom_message">local</stringProp>
           <boolProp name="Assertion.assume_success">false</boolProp>
         </ResponseAssertion>
         <hashTree/>
-        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Url" enabled="true">
+        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Url" enabled="false">
+          <collectionProp name="Asserion.test_strings">
+            <stringProp name="-1204607085">localhost</stringProp>
+          </collectionProp>
+          <stringProp name="Assertion.scope">all</stringProp>
+          <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
+          <intProp name="Assertion.test_type">2</intProp>
+          <stringProp name="Assertion.custom_message">local</stringProp>
+          <boolProp name="Assertion.assume_success">false</boolProp>
+        </ResponseAssertion>
+        <hashTree/>
+        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Url" enabled="false">
           <collectionProp name="Asserion.test_strings">
             <stringProp name="-1204607085">localhost</stringProp>
           </collectionProp>
@@ -283,7 +247,25 @@
           <longProp name="DurationAssertion.duration">2000</longProp>
         </DurationAssertion>
         <hashTree/>
+        <DurationAssertion guiclass="DurationAssertionGui" testclass="DurationAssertion" testname="Check Duration" enabled="false">
+          <stringProp name="Assertion.scope">all</stringProp>
+          <longProp name="DurationAssertion.duration">2000</longProp>
+        </DurationAssertion>
+        <hashTree/>
+        <DurationAssertion guiclass="DurationAssertionGui" testclass="DurationAssertion" testname="Check Duration" enabled="false">
+          <stringProp name="Assertion.scope">all</stringProp>
+          <longProp name="DurationAssertion.duration">2000</longProp>
+        </DurationAssertion>
+        <hashTree/>
         <MD5HexAssertion guiclass="MD5HexAssertionGUI" testclass="MD5HexAssertion" testname="Check MD5Hex" enabled="true">
+          <stringProp name="MD5HexAssertion.size">2bf7b8126bb7c645638e444f6e2c58a5</stringProp>
+        </MD5HexAssertion>
+        <hashTree/>
+        <MD5HexAssertion guiclass="MD5HexAssertionGUI" testclass="MD5HexAssertion" testname="Check MD5Hex" enabled="false">
+          <stringProp name="MD5HexAssertion.size">2bf7b8126bb7c645638e444f6e2c58a5</stringProp>
+        </MD5HexAssertion>
+        <hashTree/>
+        <MD5HexAssertion guiclass="MD5HexAssertionGUI" testclass="MD5HexAssertion" testname="Check MD5Hex" enabled="false">
           <stringProp name="MD5HexAssertion.size">2bf7b8126bb7c645638e444f6e2c58a5</stringProp>
         </MD5HexAssertion>
         <hashTree/>
@@ -293,12 +275,23 @@
           </collectionProp>
           <stringProp name="Assertion.scope">all</stringProp>
           <stringProp name="Assertion.test_field">Assertion.request_headers</stringProp>
-          <intProp name="Assertion.test_type">6</intProp>
-          <stringProp name="Assertion.custom_message">no cookies</stringProp>
+          <intProp name="Assertion.test_type">2</intProp>
+          <stringProp name="Assertion.custom_message">has cookies</stringProp>
           <boolProp name="Assertion.assume_success">false</boolProp>
         </ResponseAssertion>
         <hashTree/>
-        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Headers" enabled="true">
+        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Headers" enabled="false">
+          <collectionProp name="Asserion.test_strings">
+            <stringProp name="1670172271">COOKIES</stringProp>
+          </collectionProp>
+          <stringProp name="Assertion.scope">all</stringProp>
+          <stringProp name="Assertion.test_field">Assertion.request_headers</stringProp>
+          <intProp name="Assertion.test_type">2</intProp>
+          <stringProp name="Assertion.custom_message">has cookies</stringProp>
+          <boolProp name="Assertion.assume_success">false</boolProp>
+        </ResponseAssertion>
+        <hashTree/>
+        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Headers" enabled="false">
           <collectionProp name="Asserion.test_strings">
             <stringProp name="1670172271">COOKIES</stringProp>
           </collectionProp>
@@ -315,12 +308,23 @@
           </collectionProp>
           <stringProp name="Assertion.scope">all</stringProp>
           <stringProp name="Assertion.test_field">Assertion.request_data</stringProp>
-          <intProp name="Assertion.test_type">6</intProp>
+          <intProp name="Assertion.test_type">2</intProp>
           <stringProp name="Assertion.custom_message"></stringProp>
           <boolProp name="Assertion.assume_success">false</boolProp>
         </ResponseAssertion>
         <hashTree/>
-        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Text" enabled="true">
+        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Text" enabled="false">
+          <collectionProp name="Asserion.test_strings">
+            <stringProp name="-1238303749">test text</stringProp>
+          </collectionProp>
+          <stringProp name="Assertion.scope">all</stringProp>
+          <stringProp name="Assertion.test_field">Assertion.request_data</stringProp>
+          <intProp name="Assertion.test_type">2</intProp>
+          <stringProp name="Assertion.custom_message"></stringProp>
+          <boolProp name="Assertion.assume_success">false</boolProp>
+        </ResponseAssertion>
+        <hashTree/>
+        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Check Text" enabled="false">
           <collectionProp name="Asserion.test_strings">
             <stringProp name="-1238303749">test text</stringProp>
           </collectionProp>
@@ -338,42 +342,35 @@
           <stringProp name="SizeAssertion.size">4096</stringProp>
         </SizeAssertion>
         <hashTree/>
-        <SizeAssertion guiclass="SizeAssertionGui" testclass="SizeAssertion" testname="Check Size" enabled="true">
+        <SizeAssertion guiclass="SizeAssertionGui" testclass="SizeAssertion" testname="Check Size" enabled="false">
           <stringProp name="Assertion.scope">all</stringProp>
           <stringProp name="Assertion.test_field">SizeAssertion.response_network_size</stringProp>
-          <intProp name="SizeAssertion.operator">2</intProp>
+          <intProp name="SizeAssertion.operator">1</intProp>
+          <stringProp name="SizeAssertion.size">4096</stringProp>
+        </SizeAssertion>
+        <hashTree/>
+        <SizeAssertion guiclass="SizeAssertionGui" testclass="SizeAssertion" testname="Check Size" enabled="false">
+          <stringProp name="Assertion.scope">all</stringProp>
+          <stringProp name="Assertion.test_field">SizeAssertion.response_network_size</stringProp>
+          <intProp name="SizeAssertion.operator">1</intProp>
           <stringProp name="SizeAssertion.size">4096</stringProp>
         </SizeAssertion>
         <hashTree/>
         <SizeAssertion guiclass="SizeAssertionGui" testclass="SizeAssertion" testname="Check Size" enabled="true">
           <stringProp name="Assertion.scope">all</stringProp>
-          <stringProp name="Assertion.test_field">SizeAssertion.response_network_size</stringProp>
-          <intProp name="SizeAssertion.operator">3</intProp>
+          <stringProp name="Assertion.test_field">SizeAssertion.response_headers</stringProp>
+          <intProp name="SizeAssertion.operator">1</intProp>
           <stringProp name="SizeAssertion.size">4096</stringProp>
         </SizeAssertion>
         <hashTree/>
-        <SizeAssertion guiclass="SizeAssertionGui" testclass="SizeAssertion" testname="Check Size" enabled="true">
+        <SizeAssertion guiclass="SizeAssertionGui" testclass="SizeAssertion" testname="Check Size" enabled="false">
           <stringProp name="Assertion.scope">all</stringProp>
-          <stringProp name="Assertion.test_field">SizeAssertion.response_network_size</stringProp>
-          <intProp name="SizeAssertion.operator">4</intProp>
+          <stringProp name="Assertion.test_field">SizeAssertion.response_headers</stringProp>
+          <intProp name="SizeAssertion.operator">1</intProp>
           <stringProp name="SizeAssertion.size">4096</stringProp>
         </SizeAssertion>
         <hashTree/>
-        <SizeAssertion guiclass="SizeAssertionGui" testclass="SizeAssertion" testname="Check Size" enabled="true">
-          <stringProp name="Assertion.scope">all</stringProp>
-          <stringProp name="Assertion.test_field">SizeAssertion.response_network_size</stringProp>
-          <intProp name="SizeAssertion.operator">5</intProp>
-          <stringProp name="SizeAssertion.size">4096</stringProp>
-        </SizeAssertion>
-        <hashTree/>
-        <SizeAssertion guiclass="SizeAssertionGui" testclass="SizeAssertion" testname="Check Size" enabled="true">
-          <stringProp name="Assertion.scope">all</stringProp>
-          <stringProp name="Assertion.test_field">SizeAssertion.response_network_size</stringProp>
-          <intProp name="SizeAssertion.operator">6</intProp>
-          <stringProp name="SizeAssertion.size">4096</stringProp>
-        </SizeAssertion>
-        <hashTree/>
-        <SizeAssertion guiclass="SizeAssertionGui" testclass="SizeAssertion" testname="Check Size" enabled="true">
+        <SizeAssertion guiclass="SizeAssertionGui" testclass="SizeAssertion" testname="Check Size" enabled="false">
           <stringProp name="Assertion.scope">all</stringProp>
           <stringProp name="Assertion.test_field">SizeAssertion.response_headers</stringProp>
           <intProp name="SizeAssertion.operator">1</intProp>
@@ -387,6 +384,20 @@
           <stringProp name="SizeAssertion.size">4096</stringProp>
         </SizeAssertion>
         <hashTree/>
+        <SizeAssertion guiclass="SizeAssertionGui" testclass="SizeAssertion" testname="Check Size" enabled="false">
+          <stringProp name="Assertion.scope">all</stringProp>
+          <stringProp name="Assertion.test_field">SizeAssertion.response_network_size</stringProp>
+          <intProp name="SizeAssertion.operator">1</intProp>
+          <stringProp name="SizeAssertion.size">4096</stringProp>
+        </SizeAssertion>
+        <hashTree/>
+        <SizeAssertion guiclass="SizeAssertionGui" testclass="SizeAssertion" testname="Check Size" enabled="false">
+          <stringProp name="Assertion.scope">all</stringProp>
+          <stringProp name="Assertion.test_field">SizeAssertion.response_network_size</stringProp>
+          <intProp name="SizeAssertion.operator">1</intProp>
+          <stringProp name="SizeAssertion.size">4096</stringProp>
+        </SizeAssertion>
+        <hashTree/>
         <SizeAssertion guiclass="SizeAssertionGui" testclass="SizeAssertion" testname="Check Size" enabled="true">
           <stringProp name="Assertion.scope">all</stringProp>
           <stringProp name="Assertion.test_field">SizeAssertion.response_data</stringProp>
@@ -394,7 +405,35 @@
           <stringProp name="SizeAssertion.size">4096</stringProp>
         </SizeAssertion>
         <hashTree/>
+        <SizeAssertion guiclass="SizeAssertionGui" testclass="SizeAssertion" testname="Check Size" enabled="false">
+          <stringProp name="Assertion.scope">all</stringProp>
+          <stringProp name="Assertion.test_field">SizeAssertion.response_data</stringProp>
+          <intProp name="SizeAssertion.operator">1</intProp>
+          <stringProp name="SizeAssertion.size">4096</stringProp>
+        </SizeAssertion>
+        <hashTree/>
+        <SizeAssertion guiclass="SizeAssertionGui" testclass="SizeAssertion" testname="Check Size" enabled="false">
+          <stringProp name="Assertion.scope">all</stringProp>
+          <stringProp name="Assertion.test_field">SizeAssertion.response_data</stringProp>
+          <intProp name="SizeAssertion.operator">1</intProp>
+          <stringProp name="SizeAssertion.size">4096</stringProp>
+        </SizeAssertion>
+        <hashTree/>
         <SizeAssertion guiclass="SizeAssertionGui" testclass="SizeAssertion" testname="Check Size" enabled="true">
+          <stringProp name="Assertion.scope">all</stringProp>
+          <stringProp name="Assertion.test_field">SizeAssertion.response_message</stringProp>
+          <intProp name="SizeAssertion.operator">1</intProp>
+          <stringProp name="SizeAssertion.size">4096</stringProp>
+        </SizeAssertion>
+        <hashTree/>
+        <SizeAssertion guiclass="SizeAssertionGui" testclass="SizeAssertion" testname="Check Size" enabled="false">
+          <stringProp name="Assertion.scope">all</stringProp>
+          <stringProp name="Assertion.test_field">SizeAssertion.response_message</stringProp>
+          <intProp name="SizeAssertion.operator">1</intProp>
+          <stringProp name="SizeAssertion.size">4096</stringProp>
+        </SizeAssertion>
+        <hashTree/>
+        <SizeAssertion guiclass="SizeAssertionGui" testclass="SizeAssertion" testname="Check Size" enabled="false">
           <stringProp name="Assertion.scope">all</stringProp>
           <stringProp name="Assertion.test_field">SizeAssertion.response_message</stringProp>
           <intProp name="SizeAssertion.operator">1</intProp>


### PR DESCRIPTION
- add global enabled property for check_response, check_size, check_request - sets enabled/disable for all assertion inside those elements
- add common properties for assertions inside check_response, check_size, check_request, the enabled take precedence over global enabled property
- remove 'not' from DSL inside check assertion
- change some of the operators names inside check assertions 'contains' change to 'includes', not 'contains' to 'excludes', not 'eq' changes to 'ne'
- the check assertions can have their own name, comments and enabled properties